### PR TITLE
backend: fake -  null container backend

### DIFF
--- a/conu/backend/null/__init__.py
+++ b/conu/backend/null/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#

--- a/conu/backend/null/backend.py
+++ b/conu/backend/null/backend.py
@@ -15,7 +15,7 @@
 #
 
 """
-This is backend for nspawn engine
+This is backend for null engine - it is fake engine, what runs everything locally,
 """
 import logging
 

--- a/conu/backend/null/backend.py
+++ b/conu/backend/null/backend.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+This is backend for nspawn engine
+"""
+import logging
+
+from conu.apidefs.backend import Backend
+from container import NullContainer
+from image import NullImage
+
+logger = logging.getLogger(__name__)
+
+
+# let this class inherit docstring from its parent
+class NullBackend(Backend):
+    """
+    For more info on using the Backend classes, see documentation of
+    the parent :class:`conu.apidefs.backend.Backend` class.
+    """
+    ImageClass = NullImage
+    ContainerClass = NullContainer

--- a/conu/backend/null/container.py
+++ b/conu/backend/null/container.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Implementation of a nspawn container
+"""
+
+import logging
+import subprocess
+import xmltodict
+import time
+
+from conu.apidefs.container import Container
+from conu.utils import run_cmd
+
+
+logger = logging.getLogger(__name__)
+
+
+class NullContainer(Container):
+
+    def __init__(self, image, container_id, name=None,
+                 popen_instance=None, start_process=None, start_action=None):
+        """
+        Utilities usable for containers
+
+        :param image: image to use (instance of Image class)
+        :param container_id: id of running container (created by Image.run method)
+        :param name: optional name of container
+        :param popen_instance: not used anyhow now
+        :param start_process: subporocess instance with start process
+        :param start_action: set with 4 parameters for starting container
+        """
+        super(NullContainer, self).__init__(image, container_id, name)
+        if not name:
+            self.name = self._id
+        self.popen_instance = popen_instance
+        self.start_process = start_process
+        self.start_action = start_action
+
+    def __repr__(self):
+        # TODO: very similar to Docker method, move to API, this is the proper
+        # way
+        return "%s(image=%s, id=%s)" % (
+            self.__class__, self.image, self.get_id())
+
+    def __str__(self):
+        # TODO: move to API
+        return self.get_id()
+
+    def start(self):
+        self.start_process = NullContainer.internal_run_container(name=self.name, callback_method=self.start_action)
+        return self.start_process
+
+    def get_id(self):
+        """
+        get identifier of container
+        :return: str
+        """
+        return self._id
+
+    def inspect(self, refresh=True):
+        """
+        return cached metadata by default (a convenience method)
+
+        :param refresh: bool, returns up to date metadata if set to True
+        :return: dict
+        """
+        # TODO: move to API defs
+        return self.get_metadata(refresh=refresh)
+
+    def get_metadata(self, refresh=True):
+        """
+        return cached metadata by default
+
+        :param refresh: bool, returns up to date metadata if set to True
+        :return: dict
+        """
+        if refresh or not self._metadata:
+            output = run_cmd(["gdbus", "introspect",
+                              "--system", "-x",
+                              "--dest", "org.freedesktop.systemd1",
+                              "--object-path", "/org/freedesktop/systemd1"],
+                             return_output=True)
+            self._metadata = xmltodict.parse(output)
+        return self._metadata
+
+    def is_running(self):
+        """
+        return bool in case container is running
+
+        :return: bool
+        """
+        return self.start_process.poll() is None
+
+    def copy_to(self, src, dest):
+        """
+        copy a file or a directory from host system to a container
+
+        :param src: str, path to a file or a directory on host system
+        :param dest: str, path to a file or a directory within container
+        :return: None
+        """
+        logger.debug("copying %s from host to container at %s", src, dest)
+        cmd = ["cp", src, dest]
+        run_cmd(cmd)
+
+    def copy_from(self, src, dest):
+        """
+        copy a file or a directory from container or image to host system.
+
+        :param src: str, path to a file or a directory within container or image
+        :param dest: str, path to a file or a directory on host system
+        :return: None
+        """
+        logger.debug("copying %s from host to container at %s", src, dest)
+        cmd = ["cp", src, dest]
+        run_cmd(cmd)
+
+    def stop(self):
+        """
+        stop this  process container
+
+        :return: None
+        """
+        self.start_process.kill()
+        # give kernel 1 sec to terminate process and do async ops
+        time.sleep(1)
+
+    def kill(self, signal=None):
+        """
+        terminate process container
+
+        :param signal: Not used
+        :return:
+        """
+        self.start_process.terminate()
+        # give kernel 1 sec to terminate process and do async ops
+        time.sleep(1)
+
+    def execute(
+            self, command, *args, **kwargs):
+        """
+        execute command via systemd-run inside container
+
+        :param command: command to run inside
+        :param args: pass params to subprocess
+        :param kwargs: pass params to subprocess
+        :return: subprocess object
+        """
+
+        return subprocess.Popen(command, *args, **kwargs)
+
+    def selfcheck(self):
+        """
+        Test if default command will pass, it is more important for nspawn, because it happens that
+        it does not returns anything
+
+        :return: bool
+        """
+
+        return True
+
+    def mount(self, mount_point=None):
+        """
+        mount filesystem inside, container (image)
+
+        :param mount_point: str, where to mount
+        :return: NspawnImageFS instance
+        """
+        return self.image.mount(mount_point=mount_point)
+
+    @staticmethod
+    def internal_run_container(name, callback_method, foreground=False):
+        """
+        Internal method what runs container process
+
+        :param name: str - name of container
+        :param callback_method: list - how to invoke container
+        :param foreground: bool run in background by default
+        :return: suprocess instance
+        """
+        if callback_method[1]:
+            logger.info("Stating machine (command) {}".format(name))
+            container_process = callback_method[0](callback_method[1], *callback_method[2], **callback_method[3])
+            if foreground:
+                pass
+                #logger.info("wait for command is finished" % name)
+                #container_process.communicate()
+            logger.info("machine: %s starting finished" % name)
+            return container_process
+

--- a/conu/backend/null/container.py
+++ b/conu/backend/null/container.py
@@ -20,11 +20,10 @@ Implementation of a fake container. Runs commands on localhost
 
 import logging
 import subprocess
-import xmltodict
 import time
 
 from conu.apidefs.container import Container
-from conu.utils import run_cmd
+from conu.utils import run_cmd, convert_kv_to_dict
 
 
 logger = logging.getLogger(__name__)
@@ -90,12 +89,8 @@ class NullContainer(Container):
         :return: dict
         """
         if refresh or not self._metadata:
-            output = run_cmd(["gdbus", "introspect",
-                              "--system", "-x",
-                              "--dest", "org.freedesktop.systemd1",
-                              "--object-path", "/org/freedesktop/systemd1"],
-                             return_output=True)
-            self._metadata = xmltodict.parse(output)
+            output = run_cmd(["machinectl", "show", ".host"], return_output=True)
+            self._metadata = convert_kv_to_dict(output)
         return self._metadata
 
     def is_running(self):

--- a/conu/backend/null/container.py
+++ b/conu/backend/null/container.py
@@ -15,7 +15,7 @@
 #
 
 """
-Implementation of a nspawn container
+Implementation of a fake container. Runs commands on localhost
 """
 
 import logging
@@ -166,8 +166,7 @@ class NullContainer(Container):
 
     def selfcheck(self):
         """
-        Test if default command will pass, it is more important for nspawn, because it happens that
-        it does not returns anything
+        It is true, because host is running
 
         :return: bool
         """

--- a/conu/backend/null/container.py
+++ b/conu/backend/null/container.py
@@ -21,6 +21,7 @@ Implementation of a fake container. Runs commands on localhost
 import logging
 import subprocess
 import time
+import json
 
 from conu.apidefs.container import Container
 from conu.utils import run_cmd, convert_kv_to_dict
@@ -89,8 +90,13 @@ class NullContainer(Container):
         :return: dict
         """
         if refresh or not self._metadata:
-            output = run_cmd(["machinectl", "show", ".host"], return_output=True)
-            self._metadata = convert_kv_to_dict(output)
+            try:
+                output = run_cmd(["machinectl", "show", ".host"], return_output=True)
+                self._metadata = convert_kv_to_dict(output)
+            except subprocess.CalledProcessError:
+                try:
+                    output = run_cmd(["lshw", "-json"], return_output=True)
+                    self._metadata = json.loads(output)
         return self._metadata
 
     def is_running(self):

--- a/conu/backend/null/container.py
+++ b/conu/backend/null/container.py
@@ -94,9 +94,8 @@ class NullContainer(Container):
                 output = run_cmd(["machinectl", "show", ".host"], return_output=True)
                 self._metadata = convert_kv_to_dict(output)
             except subprocess.CalledProcessError:
-                try:
-                    output = run_cmd(["lshw", "-json"], return_output=True)
-                    self._metadata = json.loads(output)
+                output = run_cmd(["lshw", "-json"], return_output=True)
+                self._metadata = json.loads(output)
         return self._metadata
 
     def is_running(self):

--- a/conu/backend/null/image.py
+++ b/conu/backend/null/image.py
@@ -141,7 +141,7 @@ class NullImage(Image):
         """
         return NullImageFS(self, mount_point=mount_point)
 
-    def run(self, command=None, foreground=False, *args, **kwargs):
+    def run_via_binary(self, command=None, foreground=False, *args, **kwargs):
         command = deepcopy(command) or []
         machine_name = " ".join(command)
         callback_method = (subprocess.Popen, command, args, kwargs)
@@ -161,4 +161,4 @@ class NullImage(Image):
         :param kwargs: pass args to run command
         :return:  process or NullContianer instance
         """
-        return self.run(foreground=True, *args, **kwargs)
+        return self.run_via_binary(foreground=True, *args, **kwargs)

--- a/conu/backend/null/image.py
+++ b/conu/backend/null/image.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Utilities related to manipulate nspawn images.
+"""
+
+import logging
+import subprocess
+from copy import deepcopy
+
+from container import NullContainer
+from conu.apidefs.filesystem import Filesystem
+from conu.apidefs.image import Image
+from conu.utils import run_cmd
+
+logger = logging.getLogger(__name__)
+
+
+class NullImageFS(Filesystem):
+
+    def __init__(self, image, mount_point=None):
+        """
+        Raises CommandDoesNotExistException if the command is not present on the system.
+
+        :param image: instance of NspawnImage
+        :param mount_point: str, directory where the filesystem will be mounted
+        """
+        self.mount_point_exists = False
+        super(NullImageFS, self).__init__(image, mount_point=mount_point)
+        self.image = image
+
+
+class NullImage(Image):
+    """
+    Utility functions for work with base system) null copntainer.
+    """
+    special_separator = "_"
+
+    def __init__(self, repository="", tag=""):
+        """
+        :param repository: not used
+        :param tag: not used
+        """
+
+        self.container_process = None
+
+        super(NullImage, self).__init__(repository, tag=tag)
+
+    def __repr__(self):
+        return "NullImage(repository=%s, tag=%s)" % (self.name, self.tag)
+
+    def __str__(self):
+        return self.get_full_name()
+
+    def get_full_name(self):
+        """
+        Provide full, complete image name
+
+        :return: str
+        """
+        return " ".join([self.name, self.tag])
+
+    def get_id(self):
+        """
+        get unique identifier of this image
+
+        :return: str
+        """
+
+        if self._id is None:
+            self._id = run_cmd(["uname", "-a"], return_output=True).split("\n")[0].strip()
+        return self._id
+
+    def is_present(self):
+        """
+        Check if image is already imported in images
+
+        :return: bool
+        """
+        return True
+
+    def pull(self):
+        """
+        Pull this image from URL. Raises an exception if the image is not found in
+        the registry.
+
+        :return: None
+        """
+        pass
+
+
+    def inspect(self, refresh=True):
+        """
+        return cached metadata by default (a convenience method)
+
+        :param refresh: bool, update the metadata with up to date content
+        :return: dict
+        """
+        # TODO: move to API it is same
+        return self.get_metadata(refresh=refresh)
+
+    def get_metadata(self, refresh=True):
+        """
+        return cached metadata by default
+
+        :param refresh: bool, update the metadata with up to date content
+        :return: dict
+        """
+        output = {}
+        if refresh or not self._metadata:
+            whole_output = run_cmd(["mount", "-v"], return_output=True)
+            for line in whole_output.split("\n"):
+                stripped = line.strip()
+                if stripped:
+                    what, notused, where, notused, fstype, opts = line.split(" ", 6)
+                    output[where] = [what, fstype, opts]
+            self._metadata = output
+        return self._metadata
+
+    def mount(self, mount_point=None):
+        """
+        mount image filesystem
+
+        :param mount_point: str, directory where the filesystem will be mounted
+        :return: instance of NspawnImageFS
+        """
+        return NullImageFS(self, mount_point=mount_point)
+
+    def run(self, command=None, foreground=False, *args, **kwargs):
+        command = deepcopy(command) or []
+        machine_name = " ".join(command)
+        callback_method = (subprocess.Popen, command, args, kwargs)
+        self.container_process = NullContainer.internal_run_container(name=machine_name,
+                                                                      callback_method=callback_method,
+                                                                      foreground=foreground)
+        if foreground:
+            return self.container_process
+        else:
+            return NullContainer(self, container_id=machine_name,
+                                 start_process=self.container_process, start_action=callback_method)
+
+    def run_foreground(self, *args, **kwargs):
+        """
+        Force to run process at foreground
+        :param args: pass args to run command
+        :param kwargs: pass args to run command
+        :return:  process or NullContianer instance
+        """
+        return self.run(foreground=True, *args, **kwargs)

--- a/conu/backend/null/image.py
+++ b/conu/backend/null/image.py
@@ -15,7 +15,7 @@
 #
 
 """
-Utilities related to manipulate nspawn images.
+Utilities related to manipulate fake images, it uses local machine as image.
 """
 
 import logging
@@ -82,7 +82,8 @@ class NullImage(Image):
         """
 
         if self._id is None:
-            self._id = run_cmd(["uname", "-a"], return_output=True).split("\n")[0].strip()
+            with open("/etc/machine-id") as machineidfile:
+                self._id = machineidfile.read().strip()
         return self._id
 
     def is_present(self):

--- a/requirements.sh
+++ b/requirements.sh
@@ -9,4 +9,5 @@ dnf install -y acl atomic docker libselinux-utils \
   python3-docker python2-docker \
   python3-six python2-six \
   python3-pip python2-pip \
-  python2-enum34
+  python2-enum34 \
+  lshw

--- a/tests/integration/test_more_backends.py
+++ b/tests/integration/test_more_backends.py
@@ -41,3 +41,11 @@ class VariousBackends(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    # call like:
+    # Null:
+    #   python tests/integration/test_more_backends.py
+    # Nspawn:
+    #   sudo REPOSITORY=https://download.fedoraproject.org/pub/fedora/linux/development/28/CloudImages/x86_64/images/Fedora-Cloud-Base-28-20180310.n.0.x86_64.raw.xz BACKEND=NspawnBackend python tests/integration/test_more_backends.py
+    # Docker
+    #   REPOSITORY=fedora BACKEND=DockerBackend python tests/integration/test_more_backends.py
+

--- a/tests/integration/test_more_backends.py
+++ b/tests/integration/test_more_backends.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import unittest
+import os
+
+from conu.backend.null.backend import NullBackend
+from conu.backend.nspawn.backend import NspawnBackend
+from conu.backend.docker.backend import DockerBackend
+
+logger = logging.getLogger(__name__)
+
+
+class VariousBackends(unittest.TestCase):
+    def setUp(self):
+        self.back = globals()[os.environ.get("BACKEND", "NullBackend")]()
+        self.repo = os.environ.get("REPOSITORY", "NOTHING_IMPORTANT")
+        self.image = self.back.ImageClass(repository=self.repo)
+
+    def test(self):
+        logger.debug(self.image)
+        logger.debug(self.image.get_metadata())
+        self.assertTrue(self.image.get_metadata())
+        self.cont = self.image.run(command=["sleep", "10"])
+        self.cont.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_more_backends.py
+++ b/tests/integration/test_more_backends.py
@@ -35,7 +35,7 @@ class VariousBackends(unittest.TestCase):
         logger.debug(self.image)
         logger.debug(self.image.get_metadata())
         self.assertTrue(self.image.get_metadata())
-        self.cont = self.image.run(command=["sleep", "10"])
+        self.cont = self.image.run_via_binary(command=["sleep", "10"])
         self.cont.stop()
 
 

--- a/tests/integration/test_null_backend.py
+++ b/tests/integration/test_null_backend.py
@@ -49,7 +49,7 @@ def test_backend():
 
 def test_container_basic():
     im = NullImage()
-    cont = im.run(command=["sleep", "10"])
+    cont = im.run_via_binary(command=["sleep", "10"])
     logger.debug(im.get_metadata())
     logger.debug(cont.get_metadata())
     assert cont.is_running()

--- a/tests/integration/test_null_backend.py
+++ b/tests/integration/test_null_backend.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import subprocess
+import logging
+
+from conu.backend.null.image import NullImage
+from conu.backend.null.backend import NullBackend
+
+logger = logging.getLogger(__name__)
+
+
+def test_image():
+    im1 = NullImage(repository="somename", tag="tag")
+    logger.debug(im1)
+    logger.debug(im1.get_metadata())
+    assert "somename tag" in str(im1)
+    logger.debug(im1.get_id())
+
+
+def test_image_run_foreground():
+    im = NullImage()
+    cmd = im.run_foreground(["ls", "/"]).communicate()
+    out = cmd
+    assert not out[0]
+    out = im.run_foreground(["ls", "/"], stdout=subprocess.PIPE).communicate()
+    assert "sbin" in out[0]
+
+
+def test_backend():
+    back = NullBackend
+    im = back.ImageClass()
+    out = im.run_foreground(["ls", "/"], stdout=subprocess.PIPE).communicate()
+    logger.debug(out)
+    assert "sbin" in out[0]
+
+def test_container_basic():
+    im = NullImage()
+    cont = im.run(command=["sleep", "10"])
+    logger.debug(im.get_metadata())
+    logger.debug(cont.get_metadata())
+    assert cont.is_running()
+    assert cont.selfcheck()
+    cont.stop()
+    assert cont.selfcheck()
+    assert not cont.is_running()
+    cont.start()
+    assert cont.selfcheck()
+    assert cont.is_running()
+    cont.stop()


### PR DESCRIPTION
## will be reconsidered after real request and apidef sync and cleanup
 * not existing real life usecases. Just ideas

Does that make sense, to have similar backend?

I think so, because it helps you then to handle your local system as other containers.
And it gives you also imagination how generic backend shoould look like

Usages:

1.  write generic tests, like package signature, now it is hardcoded inside ``docker image backend`` but this test is relevant for each ``image``
2. able to have same test, just replace backend for example in ``setUp`` method
3. be able to have generic backend tests in travis. unable to use nspawn there directly
4. this backend adds something like compatibility layer, because Image class is more less just fake -> just to have same hadling for various backends
5. same hadling for MTF local running (MODULE=rpm) does the same.
6. helps to think about what should be generalised in parent ``Image`` class and what in specific eg. just for  Docker backend