### PR TITLE
docker container: mount via export

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,6 @@ with DockerBackend(logging_level=logging.DEBUG) as backend:
         container.delete()
 ```
 
-Let's run it! Please make sure that you run the provided example as root, since
-`conu` utilizes [`atomic`](https://github.com/projectatomic/atomic) tool and its `mount` command, which requires you to
-be root.
-
 Let's run it and look at the logs:
 ```bash
 $ python3 examples/readme_webserver.py

--- a/conu.spec
+++ b/conu.spec
@@ -62,13 +62,11 @@ Requires:       docker
 # no s2i on centos :<
 # Requires:       source-to-image
 Requires:       acl
-Requires:       atomic
 Requires:       libselinux-utils
 %else
 # these are optional but still recommended
 Recommends:     source-to-image
 Recommends:     acl
-Recommends:     atomic
 Recommends:     libselinux-utils
 %endif
 
@@ -102,7 +100,6 @@ Requires:       docker
 # these are optional but still recommended
 Recommends:     source-to-image
 Recommends:     acl
-Recommends:     atomic
 Recommends:     libselinux-utils
 
 %description -n python3-%{pypi_name}

--- a/conu/__init__.py
+++ b/conu/__init__.py
@@ -19,7 +19,9 @@ TODO: add docs here, so `help(conu)` looks good
 """
 # docker backend
 from conu.backend.docker.backend import DockerBackend
-from conu.backend.docker.container import DockerContainer, DockerRunBuilder, DockerContainerFS
+from conu.backend.docker.container import (
+    DockerContainer, DockerRunBuilder, DockerContainerViaExportFS
+)
 from conu.backend.docker.image import (
     DockerImage, S2IDockerImage, DockerImagePullPolicy, DockerImageViaArchiveFS
 )

--- a/pytest-container.ini
+++ b/pytest-container.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -vv -m "not selinux and not release_copr and not release_pypi and not nspawn and not requires_atomic_cli"
+addopts = -vv -m "not selinux and not release_copr and not release_pypi and not nspawn"
 

--- a/requirements.sh
+++ b/requirements.sh
@@ -3,7 +3,7 @@
 set -e
 
 # old s2i breaks tests & functionality
-dnf install -y acl atomic docker libselinux-utils \
+dnf install -y acl docker libselinux-utils \
   https://kojipkgs.fedoraproject.org//packages/source-to-image/1.1.7/1.fc28/x86_64/source-to-image-1.1.7-1.fc28.x86_64.rpm \
   python3-pyxattr pyxattr \
   python3-docker python2-docker \

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -415,4 +415,3 @@ def test_layers():
         reversed = image.layers(reversed=False)
         assert reversed[-1].inspect()['ContainerConfig']['Cmd'] == punchbag_cmd
 
-    

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -20,7 +20,7 @@ import subprocess
 import pytest
 
 from conu import check_port, Probe
-from conu.utils import s2i_command_exists, atomic_command_exists, getenforce_command_exists, \
+from conu.utils import s2i_command_exists, getenforce_command_exists, \
     chcon_command_exists, setfacl_command_exists, command_exists, CommandDoesNotExistException, \
     check_docker_command_works
 
@@ -45,7 +45,6 @@ def test_probes_port():
 def test_required_binaries_exist():
     # should work since we have all the deps installed
     assert s2i_command_exists()
-    assert atomic_command_exists()
     assert getenforce_command_exists()
     assert chcon_command_exists()
     assert setfacl_command_exists()


### PR DESCRIPTION
which means, we no longer need atomic

Fixes #205 

TODO:
* [x] use `docker export` instead