### PR TITLE
get container metadata from docker metadata

### DIFF
--- a/conu/apidefs/container.py
+++ b/conu/apidefs/container.py
@@ -27,7 +27,6 @@ from six.moves.urllib.parse import urlunsplit
 from contextlib import contextmanager
 
 
-
 class Container(object):
     """
     Container class definition which contains abstract methods. The instances should call the
@@ -93,7 +92,6 @@ class Container(object):
         port = port or self.get_ports()[0]
 
         yield HttpClient(host, port, self.http_session)
-
 
     def get_id(self):
         """

--- a/conu/apidefs/container.py
+++ b/conu/apidefs/container.py
@@ -110,6 +110,15 @@ class Container(object):
         """
         raise NotImplementedError("inspect method is not implemented")
 
+    def get_metadata(self):
+        """
+        return general metadata for container
+
+        :return: ContainerMetadata
+        """
+
+        raise NotImplementedError("get_metadata method is not implemented")
+
     def get_image_name(self):
         """
         return name of the container image

--- a/conu/apidefs/container.py
+++ b/conu/apidefs/container.py
@@ -103,14 +103,14 @@ class Container(object):
         """
         raise NotImplementedError("get_id method is not implemented")
 
-    def get_metadata(self, refresh=False):
+    def inspect(self, refresh=False):
         """
         return cached metadata by default
 
         :param refresh: bool, returns up to date metadata if set to True
         :return: dict
         """
-        raise NotImplementedError("get_metadata method is not implemented")
+        raise NotImplementedError("inspect method is not implemented")
 
     def get_image_name(self):
         """

--- a/conu/apidefs/image.py
+++ b/conu/apidefs/image.py
@@ -69,7 +69,7 @@ class Image(object):
         """
         raise NotImplementedError("load_from_file method is not implemented")
 
-    def get_metadata(self, refresh=False):
+    def inspect(self, refresh=False):
         """
         return cached metadata by default
 

--- a/conu/apidefs/metadata.py
+++ b/conu/apidefs/metadata.py
@@ -105,10 +105,28 @@ class ContainerStatus(enum.Enum):
     This Enum defines the status of container
     """
 
-    CREATED = 0
-    RESTARTING = 1
-    RUNNING = 2
-    REMOVING = 3
-    PAUSED = 4
-    EXITED = 5
-    DEAD = 6
+    RUNNING = 0
+    NOT_RUNNING = 1
+    UNKNOWN = 2
+    FAILED = 3
+
+    @classmethod
+    def get_from_docker(cls, string, exit_code):
+        if exit_code != 0:
+            return ContainerStatus.FAILED
+        elif string == 'created':
+            return ContainerStatus.NOT_RUNNING
+        elif string == 'restarting':
+            return ContainerStatus.UNKNOWN
+        elif string == 'running':
+            return ContainerStatus.RUNNING
+        elif string == 'removing':
+            return ContainerStatus.UNKNOWN
+        elif string == 'paused':
+            return ContainerStatus.NOT_RUNNING
+        elif string == 'exited':
+            return ContainerStatus.NOT_RUNNING
+        elif string == 'dead':
+            return ContainerStatus.FAILED
+        else:
+            return ContainerStatus.UNKNOWN

--- a/conu/apidefs/metadata.py
+++ b/conu/apidefs/metadata.py
@@ -47,8 +47,8 @@ class ContainerMetadata(Metadata):
         :param env_variables: dict, {name: value}
         :param image: Image, reference to Image instance
         :param exposed_ports: list, list of exposed ports
-        :param port_mappings: dict, dictionary of port mappings {"host_port": ["container_port"]}, example:
-            - {"8080":["80", "443"]} map port 80 and 443 in the container to port 8080 on the host
+        :param port_mappings: dict, dictionary of port mappings {"container_port": [host_port1]}, example:
+            - {"1111/tcp":[1234, 4567]} bind host ports 1234 and 4567 to a single container port 1111/tcp
         :param hostname: str, hostname
         :param ipv4_addresses: dict, {address: port}
         :param ipv6_addresses: dict, {address: port}

--- a/conu/apidefs/metadata.py
+++ b/conu/apidefs/metadata.py
@@ -47,8 +47,8 @@ class ContainerMetadata(Metadata):
         :param env_variables: dict, {name: value}
         :param image: Image, reference to Image instance
         :param exposed_ports: list, list of exposed ports
-        :param port_mappings: dict, dictionary of port mappings {"host_port": "container_port"}, example:
-            - {"8080":"80"} map port 80 in the container to port 8080 on the host
+        :param port_mappings: dict, dictionary of port mappings {"host_port": ["container_port"]}, example:
+            - {"8080":["80", "443"]} map port 80 and 443 in the container to port 8080 on the host
         :param hostname: str, hostname
         :param ipv4_addresses: dict, {address: port}
         :param ipv6_addresses: dict, {address: port}

--- a/conu/backend/docker/backend.py
+++ b/conu/backend/docker/backend.py
@@ -88,7 +88,7 @@ class DockerBackend(Backend):
 
         Container objects returned from this methods will contain a limited
         amount of metadata in property `short_metadata`. These are just a subset
-        of `.get_metadata()`, but don't require an API call against dockerd.
+        of `.inspect()`, but don't require an API call against dockerd.
 
         :return: collection of instances of :class:`conu.DockerContainer`
         """
@@ -100,7 +100,7 @@ class DockerBackend(Backend):
 
         Image objects returned from this methods will contain a limited
         amount of metadata in property `short_metadata`. These are just a subset
-        of `.get_metadata()`, but don't require an API call against dockerd.
+        of `.inspect()`, but don't require an API call against dockerd.
 
         :return: collection of instances of :class:`conu.DockerImage`
         """

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -132,7 +132,7 @@ class DockerContainer(Container):
         """
         if self._id is None:
             # FIXME: provide a better error message when key is not defined
-            self._id = self.get_metadata(refresh=False)["Id"]
+            self._id = self.inspect(refresh=False)["Id"]
         return self._id
 
     def inspect(self, refresh=True):
@@ -142,9 +142,9 @@ class DockerContainer(Container):
         :param refresh: bool, returns up to date metadata if set to True
         :return: dict
         """
-        return self.get_metadata(refresh=refresh)
+        return self.inspect(refresh=refresh)
 
-    def get_metadata(self, refresh=True):
+    def inspect(self, refresh=True):
         """
         return cached metadata by default
 
@@ -172,7 +172,7 @@ class DockerContainer(Container):
         # output = run_cmd(cmdline)
         # print(output)
         try:
-            return self.get_metadata(refresh=True)["State"]["Running"]
+            return self.inspect(refresh=True)["State"]["Running"]
         except NotFound:
             return False
 
@@ -186,7 +186,7 @@ class DockerContainer(Container):
         """
         # FIXME: be graceful in obtaining values from dict: the keys might not be set
         return [x["IPAddress"]
-                for x in self.get_metadata(refresh=True)["NetworkSettings"]["Networks"].values()]
+                for x in self.inspect(refresh=True)["NetworkSettings"]["Networks"].values()]
 
     def get_IPv6s(self):
         """
@@ -198,7 +198,7 @@ class DockerContainer(Container):
         """
         # FIXME: be graceful in obtaining values from dict: the keys might not be set
         return [x["GlobalIPv6Address"]
-                for x in self.get_metadata(refresh=True)["NetworkSettings"]["Networks"].values()]
+                for x in self.inspect(refresh=True)["NetworkSettings"]["Networks"].values()]
 
     def get_ports(self):
         """
@@ -207,7 +207,7 @@ class DockerContainer(Container):
         :return: list of str
         """
         ports = []
-        container_ports = self.get_metadata(refresh=True)["NetworkSettings"]["Ports"]
+        container_ports = self.inspect(refresh=True)["NetworkSettings"]["Ports"]
         if not container_ports:
             return ports
         for p in container_ports:
@@ -240,7 +240,7 @@ class DockerContainer(Container):
         :param port: int or None, container port
         :return: list of dict or None; dict when port=None
         """
-        port_mappings = self.get_metadata(refresh=True)["NetworkSettings"]["Ports"]
+        port_mappings = self.inspect(refresh=True)["NetworkSettings"]["Ports"]
 
         if not port:
             return port_mappings
@@ -258,7 +258,7 @@ class DockerContainer(Container):
 
         :return: str
         """
-        metadata = self.get_metadata()
+        metadata = self.inspect()
         if "Config" in metadata:
             return metadata["Config"].get("Image", None)
         return None
@@ -448,7 +448,7 @@ class DockerContainer(Container):
 
         :return: one of: 'created', 'restarting', 'running', 'paused', 'exited', 'dead'
         """
-        return self.get_metadata(refresh=True)["State"]["Status"]
+        return self.inspect(refresh=True)["State"]["Status"]
 
     def wait(self, timeout=None):
         """
@@ -466,7 +466,7 @@ class DockerContainer(Container):
 
         :return: int
         """
-        return self.get_metadata()["State"]["ExitCode"]
+        return self.inspect()["State"]["ExitCode"]
 
     def write_to_stdin(self, message):
         """
@@ -507,7 +507,7 @@ class DockerContainer(Container):
         :return: ContainerMetadata, container metadata instance
         """
 
-        docker_metadata = self.get_metadata(refresh=True)
+        docker_metadata = self.inspect(refresh=True)
 
         # format of Environment Variables from docker inspect:
         # ['DISTTAG=f26container', 'FGC=f26']

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -137,15 +137,6 @@ class DockerContainer(Container):
 
     def inspect(self, refresh=True):
         """
-        return cached metadata by default (a convenience method)
-
-        :param refresh: bool, returns up to date metadata if set to True
-        :return: dict
-        """
-        return self.inspect(refresh=refresh)
-
-    def inspect(self, refresh=True):
-        """
         return cached metadata by default
 
         :param refresh: bool, returns up to date metadata if set to True

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -515,7 +515,10 @@ class DockerContainer(Container):
         # ['DISTTAG=f26container', 'FGC=f26']
         env_variables = dict()
         for env_variable in docker_metadata['Config']['Env']:
-            env_variables.update({env_variable.split('=')[0]: env_variable.split('=')[1]})
+            try:
+                env_variables.update({env_variable.split('=', 1)[0]: env_variable.split('=', 1)[1]})
+            except IndexError:
+                pass  # wrong format of environment variable
 
         # format of image name from docker inspect:
         # sha256:8f0e66c924c0c169352de487a3c2463d82da24e9442fc097dddaa5f800df7129
@@ -543,10 +546,10 @@ class DockerContainer(Container):
         port_mappings = dict()
         for key, value in docker_metadata['HostConfig']['PortBindings'].items():
             for item in value:
-                if item['HostPort'] in port_mappings.keys():
-                    port_mappings[item['HostPort']].append(key)
+                if key in port_mappings.keys():
+                    port_mappings[key].append(int(item['HostPort']))
                 else:
-                    port_mappings.update({item['HostPort']: key})
+                    port_mappings.update({key: [int(item['HostPort'])]})
 
         container_metadata = ContainerMetadata(
             name=docker_metadata['Name'][1:],  # remove / at the beginning

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -509,8 +509,6 @@ class DockerContainer(Container):
 
         docker_metadata = self.get_metadata(refresh=True)
 
-        print(docker_metadata)
-
         # format of Environment Variables from docker inspect:
         # ['DISTTAG=f26container', 'FGC=f26']
         env_variables = dict()

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -158,7 +158,7 @@ class DockerImage(Image):
         :return: str
         """
         if self._id is None:
-            self._id = self.get_metadata(refresh=False)["Id"]
+            self._id = self.inspect(refresh=False)["Id"]
         return self._id
 
     def is_present(self):
@@ -169,7 +169,7 @@ class DockerImage(Image):
         """
         # TODO: move this method to generic API
         try:
-            return bool(self.get_metadata())
+            return bool(self.inspect())
         except docker.errors.DockerException:
             return False
 
@@ -214,9 +214,9 @@ class DockerImage(Image):
         :param refresh: bool, update the metadata with up to date content
         :return: dict
         """
-        return self.get_metadata(refresh=refresh)
+        return self.inspect(refresh=refresh)
 
-    def get_metadata(self, refresh=True):
+    def inspect(self, refresh=True):
         """
         return cached metadata by default
 

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -209,15 +209,6 @@ class DockerImage(Image):
 
     def inspect(self, refresh=True):
         """
-        return cached metadata by default (a convenience method)
-
-        :param refresh: bool, update the metadata with up to date content
-        :return: dict
-        """
-        return self.inspect(refresh=refresh)
-
-    def inspect(self, refresh=True):
-        """
         return cached metadata by default
 
         :param refresh: bool, update the metadata with up to date content

--- a/conu/backend/nspawn/container.py
+++ b/conu/backend/nspawn/container.py
@@ -115,9 +115,9 @@ class NspawnContainer(Container):
         :return: dict
         """
         # TODO: move to API defs
-        return self.inspect(refresh=refresh)
+        return self.get_metadata(refresh=refresh)
 
-    def inspect(self, refresh=True):
+    def get_metadata(self, refresh=True):
         """
         return cached metadata by default
 

--- a/conu/backend/nspawn/container.py
+++ b/conu/backend/nspawn/container.py
@@ -115,9 +115,9 @@ class NspawnContainer(Container):
         :return: dict
         """
         # TODO: move to API defs
-        return self.get_metadata(refresh=refresh)
+        return self.inspect(refresh=refresh)
 
-    def get_metadata(self, refresh=True):
+    def inspect(self, refresh=True):
         """
         return cached metadata by default
 

--- a/conu/backend/nspawn/image.py
+++ b/conu/backend/nspawn/image.py
@@ -75,7 +75,7 @@ class NspawnImageFS(Filesystem):
         # TODO RFE: use libguestfs if possible
         # TODO: allow pass partition number to mount exact partition of disc
         self.loopdevice = run_cmd(
-            ["losetup", "--show", "-f", self.image.get_metadata()["Path"]],
+            ["losetup", "--show", "-f", self.image.inspect["Path"]],
             return_output=True).strip()
         run_cmd(["partprobe", self.loopdevice])
         partitions = glob.glob("{}*".format(self.loopdevice))
@@ -267,7 +267,7 @@ class NspawnImage(Image):
         :param tag: str - tag for image
         :return: NspawnImage instance
         """
-        source = self.get_metadata()["Path"]
+        source = self.inspect()["Path"]
         logger.debug("Create Snapshot: %s -> %s" % (source, name))
         # FIXME: actually create the snapshot via clone command
         if name and tag:
@@ -293,9 +293,9 @@ class NspawnImage(Image):
         :return: dict
         """
         # TODO: move to API it is same
-        return self.get_metadata(refresh=refresh)
+        return self.inspect(refresh=refresh)
 
-    def get_metadata(self, refresh=True):
+    def inspect(self, refresh=True):
         """
         return cached metadata by default
 
@@ -397,7 +397,7 @@ class NspawnImage(Image):
             "--machine",
             machine_name,
             "-i",
-            self.get_metadata()["Path"]] + additional_opts + command
+            self.inspect()["Path"]] + additional_opts + command
         logger.debug("Start command: %s" % " ".join(systemd_command))
         callback_method = (subprocess.Popen, systemd_command, inernalargs, internalkw)
         self.container_process = NspawnContainer.internal_run_container(

--- a/conu/backend/nspawn/image.py
+++ b/conu/backend/nspawn/image.py
@@ -75,7 +75,7 @@ class NspawnImageFS(Filesystem):
         # TODO RFE: use libguestfs if possible
         # TODO: allow pass partition number to mount exact partition of disc
         self.loopdevice = run_cmd(
-            ["losetup", "--show", "-f", self.image.inspect["Path"]],
+            ["losetup", "--show", "-f", self.image.get_metadata()["Path"]],
             return_output=True).strip()
         run_cmd(["partprobe", self.loopdevice])
         partitions = glob.glob("{}*".format(self.loopdevice))
@@ -267,7 +267,7 @@ class NspawnImage(Image):
         :param tag: str - tag for image
         :return: NspawnImage instance
         """
-        source = self.inspect()["Path"]
+        source = self.get_metadata()["Path"]
         logger.debug("Create Snapshot: %s -> %s" % (source, name))
         # FIXME: actually create the snapshot via clone command
         if name and tag:
@@ -293,9 +293,9 @@ class NspawnImage(Image):
         :return: dict
         """
         # TODO: move to API it is same
-        return self.inspect(refresh=refresh)
+        return self.get_metadata(refresh=refresh)
 
-    def inspect(self, refresh=True):
+    def get_metadata(self, refresh=True):
         """
         return cached metadata by default
 
@@ -397,7 +397,7 @@ class NspawnImage(Image):
             "--machine",
             machine_name,
             "-i",
-            self.inspect()["Path"]] + additional_opts + command
+            self.get_metadata()["Path"]] + additional_opts + command
         logger.debug("Start command: %s" % " ".join(systemd_command))
         callback_method = (subprocess.Popen, systemd_command, inernalargs, internalkw)
         self.container_process = NspawnContainer.internal_run_container(

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -57,7 +57,7 @@ def test_image():
     with DockerBackend() as backend:
         image = backend.ImageClass(FEDORA_MINIMAL_REPOSITORY, tag=FEDORA_MINIMAL_REPOSITORY_TAG)
         assert "Config" in image.inspect()
-        assert "Config" in image.get_metadata()
+        assert "Config" in image.inspect()
         assert "fedora-minimal:26" in image.get_full_name()
         assert "registry.fedoraproject.org/fedora-minimal:26" == str(image)
         assert "DockerImage(repository=%s, tag=%s)" % (FEDORA_MINIMAL_REPOSITORY,
@@ -85,7 +85,7 @@ def test_container():
         )
         try:
             assert "Config" in c.inspect()
-            assert "Config" in c.get_metadata()
+            assert "Config" in c.inspect()
             assert c.get_id() == str(c)
             assert repr(c)
             assert isinstance(c.get_id(), string_types)
@@ -346,10 +346,10 @@ def test_run_with_volumes_metadata_check():
                                    pull_policy=DockerImagePullPolicy.NEVER)
         container = image.run_via_binary(volumes=(Directory('/usr/bin'), "/mountpoint", "Z"))
 
-        binds = container.get_metadata()["HostConfig"]["Binds"]
+        binds = container.inspect ()["HostConfig"]["Binds"]
         assert "/usr/bin:/mountpoint:Z" in binds
 
-        mount = container.get_metadata()["Mounts"][0]
+        mount = container.inspect()["Mounts"][0]
         print(mount)
         assert mount["Source"] == "/usr/bin"
         assert mount["Destination"] == "/mountpoint"

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -426,6 +426,8 @@ def test_metadata():
                                                                '--name', 'my_container',
                                                                '-p', '1234:12345',
                                                                '-p', '123:12345',
+                                                               '-p', '8080',
+                                                               '-p', '444:8080',
                                                                '--hostname', 'my_hostname',
                                                                '-e', 'ENV1=my_env',
                                                                '-e', 'ASD=',
@@ -435,7 +437,7 @@ def test_metadata():
                                                                ])
         )
 
-        container_metadata = c.get_container_metadata()
+        container_metadata = c.get_metadata()
 
         try:
             assert container_metadata.command == ["cat"]
@@ -445,11 +447,9 @@ def test_metadata():
             assert container_metadata.env_variables["A"] == "B=C=D"
             assert container_metadata.hostname == "my_hostname"
             assert "XYZ" not in list(container_metadata.env_variables.keys())
-            assert container_metadata.port_mappings["1234"] == "12345/tcp"
-            assert container_metadata.port_mappings["123"] == "12345/tcp"
-            assert container_metadata.exposed_ports == ["12345/tcp"]
+            assert container_metadata.port_mappings == {'12345/tcp': [1234, 123], '8080/tcp': [None, 444]}
+            assert container_metadata.exposed_ports == ["12345/tcp", "8080/tcp"]
             assert container_metadata.labels["testlabel1"] == "testvalue1"
             assert container_metadata.status == ContainerStatus.RUNNING
         finally:
             c.delete(force=True)
-

--- a/tests/integration/test_nspawn_backend.py
+++ b/tests/integration/test_nspawn_backend.py
@@ -44,7 +44,7 @@ class TestNspawnBackend(object):
         im1 = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                           location=url)
         logger.debug("%s", im1)
-        logger.debug("%s", im1.inspect())
+        logger.debug("%s", im1.get_metadata())
         logger.debug("%s", im1.get_id())
         logger.debug("%s", im1.get_full_name())
 
@@ -89,7 +89,7 @@ class TestNspawnBackend(object):
             repositories=bootstrap_repos,
             name="bootstrapped",
             additional_packages=["fedora-release"])
-        logger.debug(im.inspect())
+        logger.debug(im.get_metadata())
         out = im.run_foreground(["ls", "/"], stdout=subprocess.PIPE).communicate()
         assert "sbin" in out[0]
         out = im.run_foreground(
@@ -108,8 +108,8 @@ class TestNspawnBackend(object):
         im = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                          location=url)
         cont = im.run_via_binary()
-        logger.debug(im.inspect())
-        logger.debug(cont.inspect())
+        logger.debug(im.get_metadata())
+        logger.debug(cont.get_metadata())
         assert cont.is_running()
         assert cont.selfcheck()
         cont.stop()

--- a/tests/integration/test_nspawn_backend.py
+++ b/tests/integration/test_nspawn_backend.py
@@ -44,7 +44,7 @@ class TestNspawnBackend(object):
         im1 = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                           location=url)
         logger.debug("%s", im1)
-        logger.debug("%s", im1.get_metadata())
+        logger.debug("%s", im1.inspect())
         logger.debug("%s", im1.get_id())
         logger.debug("%s", im1.get_full_name())
 
@@ -89,7 +89,7 @@ class TestNspawnBackend(object):
             repositories=bootstrap_repos,
             name="bootstrapped",
             additional_packages=["fedora-release"])
-        logger.debug(im.get_metadata())
+        logger.debug(im.inspect())
         out = im.run_foreground(["ls", "/"], stdout=subprocess.PIPE).communicate()
         assert "sbin" in out[0]
         out = im.run_foreground(
@@ -108,8 +108,8 @@ class TestNspawnBackend(object):
         im = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                          location=url)
         cont = im.run_via_binary()
-        logger.debug(im.get_metadata())
-        logger.debug(cont.get_metadata())
+        logger.debug(im.inspect())
+        logger.debug(cont.inspect())
         assert cont.is_running()
         assert cont.selfcheck()
         cont.stop()


### PR DESCRIPTION
- get_container_metadata implemented in Docker backend
- minor change in ContainerMetadata, port_mappings is now dict {"host_port": [list_of_container_ports]}
- test is provided

We need to discuss the naming of methods here, get_metadata and get_container_metadata sounds similar what can be confusing for users.