### PR TITLE
docker run parameters

### DIFF
--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -129,7 +129,7 @@ class DockerRunBuilder(object):
         parser.add_argument("--health-timeout", action="store", dest="health_timeout", type=int)
         parser.add_argument("--no-healthcheck", action="store_true", dest="no_healthcheck")
 
-        args = parser.parse_args(args=self.options)
+        args, _ = parser.parse_known_args(args=self.options)
         command = self.arguments
 
         options_dict = vars(args)

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -177,18 +177,15 @@ class DockerRunBuilder(object):
                         # format - ip:hostPort:containerPort
                         # create dictionary - {'1111/tcp': ('127.0.0.1', 1111)}
                         dictionary[split_array[2]] = (split_array[0], int(split_array[1]))
-                    pass
                 elif colon_count == 1:
                     # format - hostPort:containerPort
                     # create dictionary - {'2222/tcp': 3333}
                     split_array = port_string.split(':')
                     dictionary[split_array[1]] = int(split_array[0])
-                    pass
                 elif colon_count == 0:
                     # format - containerPort
                     # create dictionary - {'2222/tcp': None}
                     dictionary[port_string] = None
-                    pass
                 else:
                     ConuException('Wrong format of port mappings')
 
@@ -199,7 +196,7 @@ class DockerRunBuilder(object):
                                                          command=command, detach=options_dict['detach'],
                                                          devices=options_dict['devices'], dns=options_dict['dns'],
                                                          entrypoint=options_dict['entrypoint'],
-                                                         environment=options_dict['env_variables'],
+                                                         env_variables=options_dict['env_variables'],
                                                          group_add=options_dict['group_add'],
                                                          healthcheck=options_dict['healthcheck'],
                                                          hostname=options_dict['hostname'],
@@ -214,7 +211,7 @@ class DockerRunBuilder(object):
                                                          network=options_dict['network'],
                                                          pids_limit=options_dict['pids_limit'],
                                                          platform=options_dict['platform'],
-                                                         ports=options_dict['port_mappings'],
+                                                         port_mappings=options_dict['port_mappings'],
                                                          privileged=options_dict['privileged'],
                                                          publish_all_ports=options_dict['publish_all_ports'],
                                                          read_only=options_dict['read_only'],

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -26,10 +26,12 @@ import subprocess
 from tempfile import mkdtemp
 
 from docker.errors import NotFound
+from docker.types import Healthcheck
 
 from conu.apidefs.container import Container
 from conu.apidefs.image import Image
 from conu.apidefs.metadata import ContainerStatus
+from conu.backend.docker.container_parameters import DockerContainerParameters
 from conu.apidefs.filesystem import Filesystem
 from conu.apidefs.metadata import ContainerMetadata
 from conu.backend.docker.client import get_client
@@ -69,6 +71,131 @@ class DockerRunBuilder(object):
     def build(self):
         return self.binary + self.global_options + self.command + self.options + \
             ["-l", CONU_ARTIFACT_TAG] + [self.image_name] + self.arguments
+
+    def get_parameters(self):
+        """
+        Parse DockerRunBuilder options and create object with properties for docker-py run command
+        :return: DockerContainerParameters
+        """
+        import argparse
+        parser = argparse.ArgumentParser(add_help=False)
+
+        # without parameter
+        parser.add_argument("-i", "--interactive", action="store_true", dest="stdin_open")
+        parser.add_argument("-d", "--detach", action="store_true", dest="detach")
+        parser.add_argument("-t", "--tty", action="store_true", dest="tty")
+        parser.add_argument("--init", action="store_true", dest="init")
+        parser.add_argument("--privileged", action="store_true", dest="privileged")
+        parser.add_argument("-P", "--publish-all", action="store_true", dest="publish_all_ports")
+        parser.add_argument("--read-only", action="store_true", dest="read_only")
+        parser.add_argument("--rm", action="store_true", dest="remove")
+
+        # string parameter
+        parser.add_argument("-h", "--hostname", action="store", dest="hostname")
+        parser.add_argument("--name", action="store", dest="name")
+        parser.add_argument("--ipc", action="store", dest="ipc_mode")
+        parser.add_argument("--isolation", action="store", dest="isolation")
+        parser.add_argument("--mac-address", action="store", dest="mac_address")
+        parser.add_argument("-m", "--memory", action="store", dest="mem_limit")
+        parser.add_argument("--network", action="store", dest="network")
+        parser.add_argument("--platform", action="store", dest="platform")
+        parser.add_argument("--runtime", action="store", dest="runtime")
+        parser.add_argument("--stop-signal", action="store", dest="stop_signal")
+        parser.add_argument("-u", "--user", action="store", dest="user")
+        parser.add_argument("-w", "--workdir", action="store", dest="working_dir")
+
+        # int parameter
+        parser.add_argument("--pids-limit", action="store", dest="pids_limit", type=int)
+
+        # list parameter
+        parser.add_argument("--entrypoint", action="append", dest="entrypoint")
+        parser.add_argument("-e", "--env", action="append", dest="env_variables")
+        parser.add_argument("--cap-add", action="append", dest="cap_add")
+        parser.add_argument("--cap-drop", action="append", dest="cap_drop")
+        parser.add_argument("--device", action="append", dest="devices")
+        parser.add_argument("--dns", action="append", dest="dns")
+        parser.add_argument("--group-add", action="append", dest="group_add")
+        parser.add_argument("--mount", action="append", dest="mounts")
+        parser.add_argument("-v", "--volume", action="append", dest="volumes")
+
+        # dict parameter
+        parser.add_argument("-l", "--label", action="append", dest="labels")
+        parser.add_argument("-p", "--publish", action="append", dest="port_mappings")
+
+        # health
+        parser.add_argument("--health-cmd", action="store", dest="health_cmd")
+        parser.add_argument("--health-interval", action="store", dest="health_interval", type=int)
+        parser.add_argument("--health-retries", action="store", dest="health_retries", type=int)
+        parser.add_argument("--health-timeout", action="store", dest="health_timeout", type=int)
+        parser.add_argument("--no-healthcheck", action="store_true", dest="no_healthcheck")
+
+        args = parser.parse_args(args=self.options)
+        command = self.arguments
+
+        options_dict = vars(args)
+
+        # create Healthcheck object
+        if not options_dict.pop("no_healthcheck", None):
+            options_dict["healthcheck"] = Healthcheck(
+                test=options_dict.pop("health_cmd", None),
+                interval=options_dict.pop("health_interval", None),
+                timeout=options_dict.pop("health_timeout", None),
+                retries=options_dict.pop("health_retries", None)
+            )
+        else:
+            options_dict['healthcheck'] = None
+
+        # {'name': 'separator'}
+        with_dictionary_parameter = {'labels': '=', 'port_mappings': ':'}
+        for name, separator in with_dictionary_parameter.items():
+            if options_dict[name] is not None:
+                dictionary = {}
+                for item in options_dict[name]:
+                    try:
+                        key, value = item.split(separator)
+                        dictionary[key] = value
+                    except ValueError:
+                        dictionary = options_dict[name]
+                        break
+                options_dict[name] = dictionary
+
+        print(options_dict)
+
+        container_parameters = DockerContainerParameters(cap_add=options_dict['cap_add'],
+                                                         cap_drop=options_dict['cap_drop'],
+                                                         command=command, detach=options_dict['detach'],
+                                                         devices=options_dict['devices'], dns=options_dict['dns'],
+                                                         entrypoint=options_dict['entrypoint'],
+                                                         environment=options_dict['env_variables'],
+                                                         group_add=options_dict['group_add'],
+                                                         healthcheck=options_dict['healthcheck'],
+                                                         hostname=options_dict['hostname'],
+                                                         init=options_dict['init'],
+                                                         ipc_mode=options_dict['ipc_mode'],
+                                                         isolation=options_dict['isolation'],
+                                                         labels=options_dict['labels'],
+                                                         mac_address=options_dict['mac_address'],
+                                                         mem_limit=options_dict['mem_limit'],
+                                                         mounts=options_dict['mounts'],
+                                                         name=options_dict['name'],
+                                                         network=options_dict['network'],
+                                                         pids_limit=options_dict['pids_limit'],
+                                                         platform=options_dict['platform'],
+                                                         ports=options_dict['port_mappings'],
+                                                         privileged=options_dict['privileged'],
+                                                         publish_all_ports=options_dict['publish_all_ports'],
+                                                         read_only=options_dict['read_only'],
+                                                         remove=options_dict['remove'],
+                                                         runtime=options_dict['runtime'],
+                                                         stdin_open=options_dict['stdin_open'],
+                                                         stop_signal=options_dict['stop_signal'],
+                                                         tty=options_dict['tty'],
+                                                         user=options_dict['user'],
+                                                         volumes=options_dict['volumes'],
+                                                         working_dir=options_dict['working_dir']
+                                                         )
+
+        return container_parameters
 
 
 class DockerContainerViaExportFS(Filesystem):

--- a/conu/backend/docker/container_parameters.py
+++ b/conu/backend/docker/container_parameters.py
@@ -1,40 +1,41 @@
-class DockerContainerParameters(object):
+from conu.apidefs.metadata import ContainerMetadata
+
+
+class DockerContainerParameters(ContainerMetadata):
 
     def __init__(self, cap_add=None, cap_drop=None, command=None, detach=False,
-                 devices=None, dns=None, entrypoint=None, environment=None, group_add=None,
+                 devices=None, dns=None, entrypoint=None, env_variables=None, group_add=None,
                  healthcheck=None, hostname=None, init=False, ipc_mode=None, isolation=None,
                  labels=None, mac_address=None, mem_limit=None, mounts=None,
                  name=None, network=None, pids_limit=None, platform=None,
-                 ports=None, privileged=False, publish_all_ports=False, read_only=False,
+                 port_mappings=None, privileged=False, publish_all_ports=False, read_only=False,
                  remove=False, runtime=None, stdin_open=False, stdout=True,
                  stderr=False, stop_signal=None, tty=False, user=None, volumes=None, working_dir=None):
         """
         See docker-py documentation: https://docker-py.readthedocs.io/en/stable/containers.html
         """
 
+        super(DockerContainerParameters, self).__init__(name=name, labels=labels, command=command,
+                                                        env_variables=env_variables, port_mappings=port_mappings,
+                                                        hostname=hostname)
+
         self.cap_add = cap_add
         self.cap_drop = cap_drop
-        self.command = command
         self.detach = detach
         self.devices = devices
         self.dns = dns
         self.entrypoint = entrypoint
-        self.environment = environment
         self.group_add = group_add
         self.healthcheck = healthcheck
-        self.hostname = hostname
         self.init = init
         self.ipc_mode = ipc_mode
         self.isolation = isolation
-        self.labels = labels
         self.mac_address = mac_address
         self.mem_limit = mem_limit
         self.mounts = mounts
-        self.name = name
         self.network = network
         self.pids_limit = pids_limit
         self.platform = platform
-        self.ports = ports
         self.privileged = privileged
         self.publish_all_ports = publish_all_ports
         self.read_only = read_only

--- a/conu/backend/docker/container_parameters.py
+++ b/conu/backend/docker/container_parameters.py
@@ -1,0 +1,50 @@
+class DockerContainerParameters(object):
+
+    def __init__(self, cap_add=None, cap_drop=None, command=None, detach=False,
+                 devices=None, dns=None, entrypoint=None, environment=None, group_add=None,
+                 healthcheck=None, hostname=None, init=False, ipc_mode=None, isolation=None,
+                 labels=None, mac_address=None, mem_limit=None, mounts=None,
+                 name=None, network=None, pids_limit=None, platform=None,
+                 ports=None, privileged=False, publish_all_ports=False, read_only=False,
+                 remove=False, runtime=None, stdin_open=False, stdout=True,
+                 stderr=False, stop_signal=None, tty=False, user=None, volumes=None, working_dir=None):
+        """
+        See docker-py documentation: https://docker-py.readthedocs.io/en/stable/containers.html
+        """
+
+        self.cap_add = cap_add
+        self.cap_drop = cap_drop
+        self.command = command
+        self.detach = detach
+        self.devices = devices
+        self.dns = dns
+        self.entrypoint = entrypoint
+        self.environment = environment
+        self.group_add = group_add
+        self.healthcheck = healthcheck
+        self.hostname = hostname
+        self.init = init
+        self.ipc_mode = ipc_mode
+        self.isolation = isolation
+        self.labels = labels
+        self.mac_address = mac_address
+        self.mem_limit = mem_limit
+        self.mounts = mounts
+        self.name = name
+        self.network = network
+        self.pids_limit = pids_limit
+        self.platform = platform
+        self.ports = ports
+        self.privileged = privileged
+        self.publish_all_ports = publish_all_ports
+        self.read_only = read_only
+        self.remove = remove
+        self.runtime = runtime
+        self.stdin_open = stdin_open
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stop_signal = stop_signal
+        self.tty = tty
+        self.user = user
+        self.volumes = volumes
+        self.working_dir = working_dir

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -35,6 +35,7 @@ from conu.apidefs.filesystem import Filesystem
 from conu.apidefs.image import Image, S2Image
 from conu.backend.docker.client import get_client
 from conu.backend.docker.container import DockerContainer, DockerRunBuilder
+from conu.backend.docker.container_parameters import DockerContainerParameters
 from conu.exceptions import ConuException
 from conu.utils import run_cmd, random_tmp_filename, s2i_command_exists, \
     graceful_get, export_docker_container_to_directory
@@ -385,13 +386,16 @@ class DockerImage(Image):
             container_name = actual_name
         return DockerContainer(self, container_id, popen_instance=popen_instance, name=container_name)
 
-    def run_via_api(self, container_params):
+    def run_via_api(self, container_params=None):
         """
         create a container using this image and run it in background via Docker-py API.
         https://docker-py.readthedocs.io/en/stable/api.html
         :param container_params: DockerContainerParameters
         :return: instance of DockerContainer
         """
+
+        if not container_params:
+            container_params = DockerContainerParameters()
 
         # Host-specific configuration
         host_config = self.d.create_host_config(auto_remove=container_params.remove,

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -385,6 +385,47 @@ class DockerImage(Image):
             container_name = actual_name
         return DockerContainer(self, container_id, popen_instance=popen_instance, name=container_name)
 
+    def run_via_api(self, container_params):
+        """
+        :param container_params:
+        :return: instance of DockerContainer
+        """
+
+        client = docker.from_env()
+        container = client.containers.run(self.get_id(), command=container_params.command,
+                                          remove=container_params.remove, cap_add=container_params.cap_add,
+                                          cap_drop=container_params.cap_drop, detach=container_params.detach,
+                                          devices=container_params.devices,
+                                          dns=container_params.dns, entrypoint=container_params.entrypoint,
+                                          environment=container_params.env_variables,
+                                          group_add=container_params.group_add,
+                                          healthcheck=container_params.healthcheck,
+                                          hostname=container_params.hostname,
+                                          init=container_params.init, ipc_mode=container_params.ipc_mode,
+                                          isolation=container_params.isolation, labels=container_params.labels,
+                                          mac_address=container_params.mac_address,
+                                          mem_limit=container_params.mem_limit,
+                                          mounts=container_params.mounts,
+                                          name=container_params.name,
+                                          network=container_params.network,
+                                          pids_limit=container_params.pids_limit,
+                                          platform=container_params.platform,
+                                          ports=container_params.port_mappings,
+                                          privileged=container_params.privileged,
+                                          publish_all_ports=container_params.publish_all_ports,
+                                          read_only=container_params.read_only,
+                                          runtime=container_params.runtime,
+                                          stdin_open=container_params.stdin_open,
+                                          stdout=container_params.stdout,
+                                          stderr=container_params.stderr,
+                                          stop_signal=container_params.stop_signal,
+                                          tty=container_params.tty,
+                                          user=container_params.user,
+                                          volumes=container_params.volumes,
+                                          working_dir=container_params.working_dir)
+
+        return DockerContainer(self, container.id, name=container.name)
+
     def has_pkgs_signed_with(self, allowed_keys):
         """
         Check signature of packages installed in image.

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -387,44 +387,50 @@ class DockerImage(Image):
 
     def run_via_api(self, container_params):
         """
-        :param container_params:
+        create a container using this image and run it in background via Docker-py API.
+        https://docker-py.readthedocs.io/en/stable/api.html
+        :param container_params: DockerContainerParameters
         :return: instance of DockerContainer
         """
 
-        client = docker.from_env()
-        container = client.containers.run(self.get_id(), command=container_params.command,
-                                          remove=container_params.remove, cap_add=container_params.cap_add,
-                                          cap_drop=container_params.cap_drop, detach=container_params.detach,
-                                          devices=container_params.devices,
-                                          dns=container_params.dns, entrypoint=container_params.entrypoint,
-                                          environment=container_params.env_variables,
-                                          group_add=container_params.group_add,
-                                          healthcheck=container_params.healthcheck,
-                                          hostname=container_params.hostname,
-                                          init=container_params.init, ipc_mode=container_params.ipc_mode,
-                                          isolation=container_params.isolation, labels=container_params.labels,
-                                          mac_address=container_params.mac_address,
-                                          mem_limit=container_params.mem_limit,
-                                          mounts=container_params.mounts,
-                                          name=container_params.name,
-                                          network=container_params.network,
-                                          pids_limit=container_params.pids_limit,
-                                          platform=container_params.platform,
-                                          ports=container_params.port_mappings,
-                                          privileged=container_params.privileged,
-                                          publish_all_ports=container_params.publish_all_ports,
-                                          read_only=container_params.read_only,
-                                          runtime=container_params.runtime,
-                                          stdin_open=container_params.stdin_open,
-                                          stdout=container_params.stdout,
-                                          stderr=container_params.stderr,
-                                          stop_signal=container_params.stop_signal,
-                                          tty=container_params.tty,
-                                          user=container_params.user,
-                                          volumes=container_params.volumes,
-                                          working_dir=container_params.working_dir)
+        # Host-specific configuration
+        host_config = self.d.create_host_config(auto_remove=container_params.remove,
+                                                cap_add=container_params.cap_add,
+                                                cap_drop=container_params.cap_drop,
+                                                devices=container_params.devices,
+                                                dns=container_params.dns,
+                                                group_add=container_params.group_add,
+                                                init=container_params.init,
+                                                ipc_mode=container_params.ipc_mode,
+                                                isolation=container_params.isolation,
+                                                mem_limit=container_params.mem_limit,
+                                                mounts=container_params.mounts,
+                                                pids_limit=container_params.pids_limit,
+                                                privileged=container_params.privileged,
+                                                publish_all_ports=container_params.publish_all_ports,
+                                                port_bindings=container_params.port_mappings,
+                                                read_only=container_params.read_only)
 
-        return DockerContainer(self, container.id, name=container.name)
+        container = self.d.create_container(self.get_id(), command=container_params.command,
+                                            detach=True,
+                                            hostname=container_params.hostname,
+                                            user=container_params.user,
+                                            stdin_open=container_params.stdin_open,
+                                            tty=container_params.tty,
+                                            ports=container_params.exposed_ports,
+                                            environment=container_params.env_variables,
+                                            volumes=container_params.volumes,
+                                            name=container_params.name,
+                                            entrypoint=container_params.entrypoint,
+                                            working_dir=container_params.working_dir,
+                                            host_config=host_config,
+                                            mac_address=container_params.mac_address,
+                                            labels=container_params.labels,
+                                            stop_signal=container_params.stop_signal,
+                                            healthcheck=container_params.healthcheck,
+                                            runtime=container_params.runtime)
+
+        return DockerContainer(self, container['Id'], name=container_params.name)
 
     def has_pkgs_signed_with(self, allowed_keys):
         """

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -390,6 +390,8 @@ class DockerImage(Image):
         """
         create a container using this image and run it in background via Docker-py API.
         https://docker-py.readthedocs.io/en/stable/api.html
+        Note: If you are using Healthchecks, be aware that support of some options were introduced
+         just with version of Docker-py API 1.29
         :param container_params: DockerContainerParameters
         :return: instance of DockerContainer
         """

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -531,8 +531,11 @@ def test_run_via_api():
 
         parameters = docker_run_builder.get_parameters()
 
+        # image will be deleted after because of "--rm" option
         c = image.run_via_api(parameters)
 
+        assert "Config" in c.inspect()
+        assert "Config" in c.get_metadata()
         assert c.get_id() == str(c)
         assert repr(c)
         assert isinstance(c.get_id(), string_types)

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -479,7 +479,8 @@ def test_docker_parameters():
                                                            '--mac-address', '92:d0:c6:0a:29:33',
                                                            '--memory', '1G', '--user', 'my_user',
                                                            '--workdir', '/tmp',
-                                                           '--env', 'ENV1=my_env', '-p', '123:12345',
+                                                           '--env', 'ENV1=my_env', '-p', '123:12345', '-p', '1444',
+                                                           '-p', '10.0.0.1::150', '-p', '10.0.0.2:2345:7654',
                                                            '--cap-add', 'MKNOD', '--cap-add', 'SYS_ADMIN',
                                                            '--cap-drop', 'SYS_ADMIN', '--device', '/dev/sdc:/dev/xvdc',
                                                            '--dns', 'www.example.com', '--group-add', 'group1',
@@ -501,7 +502,7 @@ def test_docker_parameters():
     assert parameters.user == 'my_user'
     assert parameters.working_dir == '/tmp'
     assert 'ENV1=my_env' in parameters.environment
-    assert parameters.ports == {'123': '12345'}
+    assert parameters.ports == {'12345': 123, '1444': None, '150': ('10.0.0.1', None), '7654': ('10.0.0.2', 2345)}
     assert parameters.cap_add == ['MKNOD', 'SYS_ADMIN']
     assert parameters.cap_drop == ['SYS_ADMIN']
     assert parameters.devices == ['/dev/sdc:/dev/xvdc']

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -531,11 +531,12 @@ def test_run_via_api():
 
         parameters = docker_run_builder.get_parameters()
 
-        # image will be deleted after because of "--rm" option
         c = image.run_via_api(parameters)
 
-        assert "Config" in c.inspect()
-        assert "Config" in c.get_metadata()
-        assert c.get_id() == str(c)
-        assert repr(c)
-        assert isinstance(c.get_id(), string_types)
+        try:
+            assert "Config" in c.inspect()
+            assert c.get_id() == str(c)
+            assert repr(c)
+            assert isinstance(c.get_id(), string_types)
+        finally:
+            c.delete(force=True)


### PR DESCRIPTION
based on work done in this [PR](https://github.com/dhodovsk/conu/pull/2)

Now we can convert object of type `DockerRunBuilder` and create instance of new introduced class `DockerContainerParameters`. Properties of this class can be used for running `docker run` using [docker-py API](https://github.com/docker/docker-py).

Functionality not cover all possible parameters, but they can be implemented easily in future PRs if this changes will be merged.

I will be glad for review.