### PR TITLE
drop enum34 requirment for python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-enum34
+enum34>=1.1.6 ; python_version <= '2.7'
 requests
 six
 docker


### PR DESCRIPTION
Fixes #194