### PR TITLE
Fix tests and uid and gid of nobody

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-in-container:
 	@# use it like this: `make test-in-container TEST_TARGET=tests/integration/test_utils.py`
 	docker run --net=host --rm -v /dev:/dev:ro -v /var/lib/docker:/var/lib/docker:ro --security-opt label=disable --cap-add SYS_ADMIN -ti -v /var/run/docker.sock:/var/run/docker.sock -v $(CURDIR):/src -v $(CURDIR)/pytest-container.ini:/src/pytest.ini $(TEST_IMAGE_NAME) make exec-test TEST_TARGET=$(TEST_TARGET)
 
-test-doc-examples:
+test-doc-examples: install
 	for file in $$(ls $(DOC_EXAMPLE_PATH)) ; do \
 		echo "Checking example file $$file" ; \
 		PYTHONPATH=$(CURDIR) python2 $(DOC_EXAMPLE_PATH)/$$file || exit ; \

--- a/docs/source/examples/check_env.py
+++ b/docs/source/examples/check_env.py
@@ -17,10 +17,10 @@
 import subprocess
 import time
 
-from conu import DockerBackend, DockerRunBuilder
+from conu import DockerBackend
 
 with DockerBackend() as backend:
-    image = backend.ImageClass('fedora')
+    image = backend.ImageClass("registry.fedoraproject.org/fedora", tag='27')
     additional_opts = ['-i', '-e', 'KEY=space']
 
     cont = image.run_via_binary_in_foreground(additional_opts=additional_opts, popen_params={"stdin": subprocess.PIPE})

--- a/docs/source/examples/run_image.py
+++ b/docs/source/examples/run_image.py
@@ -22,6 +22,6 @@ from conu.helpers import get_container_output
 with DockerBackend() as backend:
     # This will run the container using the supplied command, collects output and
     # cleans the container
-    output = get_container_output(backend, "fedora", ["ls", "-1", "/etc"],
+    output = get_container_output(backend, "registry.fedoraproject.org/fedora", ["ls", "-1", "/etc"],
                                   image_tag="27")
     assert "passwd" in output

--- a/requirements.sh
+++ b/requirements.sh
@@ -5,9 +5,13 @@ set -e
 # old s2i breaks tests & functionality
 dnf install -y acl docker libselinux-utils \
   source-to-image \
-  python3-pyxattr python2-pyxattr \
+  python3-pyxattr \
   python3-docker python2-docker \
   python3-six python2-six \
   python3-pip python2-pip \
   python3-pytest python2-pytest \
   python2-enum34
+
+
+# pyxattr has different naming in Fedora 27 and Fedora 28
+dnf install -y python2-pyxattr || dnf install -y pyxattr

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -412,8 +412,8 @@ def test_layers():
                 "CMD [\"usage\"]"
         ]
         assert layers[0].inspect()['ContainerConfig']['Cmd'] == punchbag_cmd
-        reversed = image.layers(reversed=False)
-        assert reversed[-1].inspect()['ContainerConfig']['Cmd'] == punchbag_cmd
+        rev = image.layers(rev=False)
+        assert rev[-1].inspect()['ContainerConfig']['Cmd'] == punchbag_cmd
 
 
 def test_metadata():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -94,16 +94,16 @@ def test_directory_acl():
 
 def test_user_ownership_int():
     p = os.path.join("/tmp/", random_str())
-    with Directory(p, user_owner=99) as d:
+    with Directory(p, user_owner=65534) as d:
         s = os.stat(d.path)
-        assert s.st_uid == 99
+        assert s.st_uid == 65534
 
 
 def test_user_ownership_str():
     p = os.path.join("/tmp/", random_str())
     with Directory(p, user_owner="nobody") as d:
         s = os.stat(d.path)
-        assert s.st_uid == 99
+        assert s.st_uid == 65534
 
 
 def test_user_ownership_404():
@@ -114,16 +114,16 @@ def test_user_ownership_404():
 
 def test_group_ownership():
     p = os.path.join("/tmp/", random_str())
-    with Directory(p, group_owner=99) as d:
+    with Directory(p, group_owner=65534) as d:
         s = os.stat(d.path)
-        assert s.st_gid == 99
+        assert s.st_gid == 65534
 
 
 def test_group_ownership_str():
     p = os.path.join("/tmp/", random_str())
     with Directory(p, group_owner="nobody") as d:
         s = os.stat(d.path)
-        assert s.st_gid == 99
+        assert s.st_gid == 65534
 
 
 def test_group_ownership_404():
@@ -136,8 +136,8 @@ def test_ownership():
     p = os.path.join("/tmp/", random_str())
     with Directory(p, user_owner="nobody", group_owner="nobody") as d:
         s = os.stat(d.path)
-        assert s.st_gid == 99
-        assert s.st_uid == 99
+        assert s.st_gid == 65534
+        assert s.st_uid == 65534
 
 
 def test_graceful_get():


### PR DESCRIPTION
 - Id of user nobody has been changed in fedora 28: https://fedoraproject.org/wiki/Changes/RenameNobodyUser

 - use whole name for images - `docker.io/fedora` was breaking this example
