### PR TITLE
Use Popen in run_cmd and pipe outputs to logger

### DIFF
--- a/conu/utils/__init__.py
+++ b/conu/utils/__init__.py
@@ -123,13 +123,13 @@ def run_cmd(cmd, return_output=False, ignore_status=False, **kwargs):
     """
     logger.debug('command: "%s"' % ' '.join(cmd))
     try:
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                   universal_newlines=True, **kwargs)
+        output = process.communicate()[0]
+        logger.debug(output)
         if return_output:
-            return subprocess.check_output(cmd,
-                                           stderr=subprocess.STDOUT,
-                                           universal_newlines=True,
-                                           **kwargs)
-        else:
-            subprocess.check_call(cmd, **kwargs)
+            return output
+
     except subprocess.CalledProcessError as cpe:
         if ignore_status:
             if return_output:

--- a/conu/utils/__init__.py
+++ b/conu/utils/__init__.py
@@ -122,22 +122,21 @@ def run_cmd(cmd, return_output=False, ignore_status=False, **kwargs):
     :return: None or str
     """
     logger.debug('command: "%s"' % ' '.join(cmd))
-    try:
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                   universal_newlines=True, **kwargs)
-        output = process.communicate()[0]
-        logger.debug(output)
-        if return_output:
-            return output
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                               universal_newlines=True, **kwargs)
+    output = process.communicate()[0]
+    logger.debug(output)
 
-    except subprocess.CalledProcessError as cpe:
+    if process.returncode > 0:
         if ignore_status:
             if return_output:
-                return cpe.output
+                return output
             else:
-                return cpe.returncode
+                return process.returncode
         else:
-            raise cpe
+            raise subprocess.CalledProcessError(cmd=cmd, returncode=process.returncode)
+    if return_output:
+        return output
 
 
 def mkstemp(dir=None):

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -73,7 +73,7 @@ def test_run_cmd():
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         ret = run_cmd(["sh", "-c", "exit 5"])
         assert not ret
-    assert 5 == excinfo.value.returncode
+    assert excinfo.value.returncode == 5
 
     ret = run_cmd(["sh", "-c", "exit 5"], ignore_status=True)
-    assert 5 == ret
+    assert ret == 5

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -22,7 +22,7 @@ import pytest
 from conu import check_port, Probe
 from conu.utils import s2i_command_exists, getenforce_command_exists, \
     chcon_command_exists, setfacl_command_exists, command_exists, CommandDoesNotExistException, \
-    check_docker_command_works
+    check_docker_command_works, run_cmd
 
 
 def test_probes_port():
@@ -60,3 +60,20 @@ def test_command_exists():
 
 def test_check_docker():
     assert check_docker_command_works()
+
+
+def test_run_cmd():
+    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"])
+    assert not ret
+
+    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"],
+                  return_output=True)
+    assert ret == '1\n2\n3\n4\n5\n'
+
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        ret = run_cmd(["sh", "-c", "exit 5"])
+        assert not ret
+    assert 5 == excinfo.value.returncode
+
+    ret = run_cmd(["sh", "-c", "exit 5"], ignore_status=True)
+    assert 5 == ret

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -63,10 +63,10 @@ def test_check_docker():
 
 
 def test_run_cmd():
-    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"])
+    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 0.01; done"])
     assert not ret
 
-    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"],
+    ret = run_cmd(["sh", "-c", "for x in `seq 1 5`; do echo $x; sleep 0.01; done"],
                   return_output=True)
     assert ret == '1\n2\n3\n4\n5\n'
 


### PR DESCRIPTION
Fixes #211 

_Old behaviour_

```
>>> from conu.utils import run_cmd
>>> ret = run_cmd(['ls'])
CHANGELOG.md	  docs			pytest.ini	   setup.cfg
CONTRIBUTING.md   examples		README.md	   setup.py
conu		  LICENSE		release-conf.yaml  test-requirements.sh
conu.spec	  Makefile		requirements.in    tests
Dockerfile	  MANIFEST.in		requirements.sh    Vagrantfile
Dockerfile.tests  pytest-container.ini	requirements.txt
>>> ret
>>> ret = run_cmd(['ls'], return_output=True)
>>> ret
'CHANGELOG.md\nCONTRIBUTING.md\nconu\nconu.spec\nDockerfile\nDockerfile.tests\ndocs\nexamples\nLICENSE\nMakefile\nMANIFEST.in\npytest-container.ini\npytest.ini\nREADME.md\nrelease-conf.yaml\nrequirements.in\nrequirements.sh\nrequirements.txt\nsetup.cfg\nsetup.py\ntest-requirements.sh\ntests\nVagrantfile\n'
```

_New behaviour_

```
>>> from conu.utils import run_cmd
>>> ret = run_cmd(['ls'])
>>> ret
>>> ret = run_cmd(['ls'], return_output=True)
>>> ret
'CHANGELOG.md\nCONTRIBUTING.md\nconu\nconu.spec\nDockerfile\nDockerfile.tests\ndocs\nexamples\nLICENSE\nMakefile\nMANIFEST.in\npytest-container.ini\npytest.ini\nREADME.md\nrelease-conf.yaml\nrequirements.in\nrequirements.sh\nrequirements.txt\nsetup.cfg\nsetup.py\ntest-requirements.sh\ntests\nVagrantfile\n'
```
