### PR TITLE
skip origin and k8s tests if there is no OpenShift installed or running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ centos-ci-test: install-test-requirements container-image build-test-container t
 test-in-container:
 	@# use it like this: `make test-in-container TEST_TARGET=tests/integration/test_utils.py`
 	$(eval kubedir := $(shell mktemp -d /tmp/tmp.conu-kube-XXXXX))
-	sed -e s#"${HOME}"#/root#g ${HOME}/.kube/config > $(kubedir)/config
+	sed -e s#"${HOME}"#/root#g ${HOME}/.kube/config > $(kubedir)/config ; \
 	docker run --net=host --rm -v /dev:/dev:ro -v /var/lib/docker:/var/lib/docker:ro --security-opt label=disable --cap-add SYS_ADMIN -ti -v /var/run/docker.sock:/var/run/docker.sock -v $(CURDIR):/src -v $(CURDIR)/pytest-container.ini:/src/pytest.ini -v $(kubedir):/root/.kube $(TEST_IMAGE_NAME) make exec-test TEST_TARGET=$(TEST_TARGET)
 
 test-in-vm:

--- a/conu/utils/__init__.py
+++ b/conu/utils/__init__.py
@@ -365,3 +365,15 @@ def get_oc_api_token():
         return run_cmd(["oc", "whoami", "-t"], return_output=True).rstrip()  # remove '\n'
     except subprocess.CalledProcessError as ex:
         raise ConuException("oc whoami -t failed: %s" % ex)
+
+
+def is_oc_cluster_running():
+    """
+    Check status of OpenShift cluster
+    :return: bool, True if cluster is running otherwise False
+    """
+    try:
+        run_cmd(["oc", "cluster", "status"])
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -19,215 +19,214 @@ Tests for Kubernetes backend
 """
 
 import urllib3
+import pytest
 
 from conu import DockerBackend
-from conu.backend.k8s.backend import K8sBackend
-from conu.backend.k8s.backend import K8sCleanupPolicy
+from conu.backend.k8s.backend import K8sBackend, K8sCleanupPolicy
 from conu.backend.k8s.pod import PodPhase
 from conu.backend.k8s.service import Service
 from conu.backend.k8s.deployment import Deployment
 from conu.backend.k8s.client import get_core_api
-from conu.utils import get_oc_api_token
-
+from conu.utils import get_oc_api_token, oc_command_exists, is_oc_cluster_running
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-def test_pod():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
+@pytest.mark.skipif(not oc_command_exists(), reason="OpenShift is not installed!")
+@pytest.mark.skipif(not is_oc_cluster_running(), reason="OpenShift cluster is not running!")
+class TestK8s(object):
 
-        namespace = k8s_backend.create_namespace()
+    def test_pod(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
-        with DockerBackend() as backend:
-            image = backend.ImageClass("openshift/hello-openshift")
+            namespace = k8s_backend.create_namespace()
 
-            pod = image.run_in_pod(namespace=namespace)
+            with DockerBackend() as backend:
+                image = backend.ImageClass("openshift/hello-openshift")
 
-            try:
-                pod.wait(200)
-                assert pod.is_ready()
-                assert pod.get_phase() == PodPhase.RUNNING
-            finally:
-                pod.delete()
-                assert pod.get_phase() == PodPhase.TERMINATING
-                k8s_backend.delete_namespace(namespace)
+                pod = image.run_in_pod(namespace=namespace)
 
+                try:
+                    pod.wait(200)
+                    assert pod.is_ready()
+                    assert pod.get_phase() == PodPhase.RUNNING
+                finally:
+                    pod.delete()
+                    assert pod.get_phase() == PodPhase.TERMINATING
+                    k8s_backend.delete_namespace(namespace)
 
-def test_database_deployment():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
+    def test_database_deployment(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
-        namespace = k8s_backend.create_namespace()
+            namespace = k8s_backend.create_namespace()
 
-        with DockerBackend() as backend:
-            postgres_image = backend.ImageClass("centos/postgresql-10-centos7")
+            with DockerBackend() as backend:
+                postgres_image = backend.ImageClass("centos/postgresql-10-centos7")
 
-            postgres_image_metadata = postgres_image.get_metadata()
+                postgres_image_metadata = postgres_image.get_metadata()
 
-            # set up env variables
-            db_env_variables = {"POSTGRESQL_USER": "user",
-                                "POSTGRESQL_PASSWORD": "pass",
-                                "POSTGRESQL_DATABASE": "db"}
+                # set up env variables
+                db_env_variables = {"POSTGRESQL_USER": "user",
+                                    "POSTGRESQL_PASSWORD": "pass",
+                                    "POSTGRESQL_DATABASE": "db"}
 
-            postgres_image_metadata.env_variables.update(db_env_variables)
+                postgres_image_metadata.env_variables.update(db_env_variables)
 
-            db_labels = {"app": "postgres"}
+                db_labels = {"app": "postgres"}
 
-            db_service = Service(name="database", ports=["5432"], selector=db_labels,
-                                 namespace=namespace,
-                                 create_in_cluster=True)
+                db_service = Service(name="database", ports=["5432"], selector=db_labels,
+                                     namespace=namespace,
+                                     create_in_cluster=True)
 
-            db_deployment = Deployment(name="database", selector=db_labels, labels=db_labels,
-                                       image_metadata=postgres_image_metadata, namespace=namespace,
-                                       create_in_cluster=True)
+                db_deployment = Deployment(name="database", selector=db_labels, labels=db_labels,
+                                           image_metadata=postgres_image_metadata,
+                                           namespace=namespace,
+                                           create_in_cluster=True)
 
-            try:
-                db_deployment.wait(200)
-                assert db_deployment.all_pods_ready()
-            finally:
-                db_deployment.delete()
-                db_service.delete()
-                k8s_backend.delete_namespace(namespace)
+                try:
+                    db_deployment.wait(200)
+                    assert db_deployment.all_pods_ready()
+                finally:
+                    db_deployment.delete()
+                    db_service.delete()
+                    k8s_backend.delete_namespace(namespace)
 
+    def test_list_pods(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
-def test_list_pods():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
+            namespace = k8s_backend.create_namespace()
 
-        namespace = k8s_backend.create_namespace()
+            with DockerBackend() as backend:
 
-        with DockerBackend() as backend:
+                image = backend.ImageClass("openshift/hello-openshift")
 
-            image = backend.ImageClass("openshift/hello-openshift")
+                pod = image.run_in_pod(namespace=namespace)
 
-            pod = image.run_in_pod(namespace=namespace)
+                try:
+                    pod.wait(200)
+                    assert any(pod.name == p.name for p in k8s_backend.list_pods())
+                finally:
+                    pod.delete()
+                    k8s_backend.delete_namespace(namespace)
 
-            try:
-                pod.wait(200)
-                assert any(pod.name == p.name for p in k8s_backend.list_pods())
-            finally:
-                pod.delete()
-                k8s_backend.delete_namespace(namespace)
+    def test_list_services(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
+            namespace = k8s_backend.create_namespace()
 
-def test_list_services():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
+            labels = {"app": "postgres"}
 
-        namespace = k8s_backend.create_namespace()
-
-        labels = {"app": "postgres"}
-
-        service = Service(name="database", ports=["5432"], selector=labels, namespace=namespace,
-                          create_in_cluster=True)
-
-        try:
-            assert any(service.name == s.name for s in k8s_backend.list_services())
-        finally:
-            service.delete()
-            k8s_backend.delete_namespace(namespace)
-
-
-def test_list_deployments():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
-
-        namespace = k8s_backend.create_namespace()
-
-        with DockerBackend() as backend:
-            postgres_image = backend.ImageClass("centos/postgresql-10-centos7")
-
-            postgres_image_metadata = postgres_image.get_metadata()
-
-            # set up env variables
-            db_env_variables = {"POSTGRESQL_USER": "user",
-                                "POSTGRESQL_PASSWORD": "pass",
-                                "POSTGRESQL_DATABASE": "db"}
-
-            postgres_image_metadata.env_variables.update(db_env_variables)
-
-            db_labels = {"app": "postgres"}
-
-            db_deployment = Deployment(name="database", selector=db_labels, labels=db_labels,
-                                       image_metadata=postgres_image_metadata, namespace=namespace,
-                                       create_in_cluster=True)
+            service = Service(name="database", ports=["5432"], selector=labels, namespace=namespace,
+                              create_in_cluster=True)
 
             try:
-                db_deployment.wait(200)
-                assert db_deployment.all_pods_ready()
-                assert any(db_deployment.name == d.name for d in k8s_backend.list_deployments())
+                assert any(service.name == s.name for s in k8s_backend.list_services())
             finally:
-                db_deployment.delete()
+                service.delete()
                 k8s_backend.delete_namespace(namespace)
 
+    def test_list_deployments(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
-def test_deployment_from_template():
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key) as k8s_backend:
+            namespace = k8s_backend.create_namespace()
 
-        namespace = k8s_backend.create_namespace()
+            with DockerBackend() as backend:
+                postgres_image = backend.ImageClass("centos/postgresql-10-centos7")
 
-        template = """
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: hello-world
-          labels:
-            app: hello-world
-        spec:
-          replicas: 3
-          selector:
-            matchLabels:
-              app: hello-world
-          template:
+                postgres_image_metadata = postgres_image.get_metadata()
+
+                # set up env variables
+                db_env_variables = {"POSTGRESQL_USER": "user",
+                                    "POSTGRESQL_PASSWORD": "pass",
+                                    "POSTGRESQL_DATABASE": "db"}
+
+                postgres_image_metadata.env_variables.update(db_env_variables)
+
+                db_labels = {"app": "postgres"}
+
+                db_deployment = Deployment(name="database", selector=db_labels, labels=db_labels,
+                                           image_metadata=postgres_image_metadata,
+                                           namespace=namespace,
+                                           create_in_cluster=True)
+
+                try:
+                    db_deployment.wait(200)
+                    assert db_deployment.all_pods_ready()
+                    assert any(db_deployment.name == d.name for d in k8s_backend.list_deployments())
+                finally:
+                    db_deployment.delete()
+                    k8s_backend.delete_namespace(namespace)
+
+    def test_deployment_from_template(self):
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key) as k8s_backend:
+
+            namespace = k8s_backend.create_namespace()
+
+            template = """
+            apiVersion: apps/v1
+            kind: Deployment
             metadata:
+              name: hello-world
               labels:
                 app: hello-world
             spec:
-              containers:
-              - name: hello-openshift
-                image: openshift/hello-openshift
-        """
+              replicas: 3
+              selector:
+                matchLabels:
+                  app: hello-world
+              template:
+                metadata:
+                  labels:
+                    app: hello-world
+                spec:
+                  containers:
+                  - name: hello-openshift
+                    image: openshift/hello-openshift
+            """
 
-        test_deployment = Deployment(namespace=namespace, from_template=template,
-                                     create_in_cluster=True)
+            test_deployment = Deployment(namespace=namespace, from_template=template,
+                                         create_in_cluster=True)
 
-        try:
-            test_deployment.wait(200)
-            assert test_deployment.all_pods_ready()
-        finally:
-            test_deployment.delete()
-            k8s_backend.delete_namespace(namespace)
+            try:
+                test_deployment.wait(200)
+                assert test_deployment.all_pods_ready()
+            finally:
+                test_deployment.delete()
+                k8s_backend.delete_namespace(namespace)
 
+    def test_cleanup(self):
 
-def test_cleanup():
+        api = get_core_api()
 
-    api = get_core_api()
+        # take just namespaces that are not in terminating state
+        number_of_namespaces = len(
+            [item for item in api.list_namespace().items if item.status.phase != "Terminating"])
 
-    # take just namespaces that are not in terminating state
-    number_of_namespaces = len(
-        [item for item in api.list_namespace().items if item.status.phase != "Terminating"])
+        api_key = get_oc_api_token()
+        with K8sBackend(api_key=api_key, cleanup=[K8sCleanupPolicy.NAMESPACES]) as k8s_backend:
 
-    api_key = get_oc_api_token()
-    with K8sBackend(api_key=api_key, cleanup=[K8sCleanupPolicy.NAMESPACES]) as k8s_backend:
+            # create two namespaces
+            k8s_backend.create_namespace()
+            k8s_backend.create_namespace()
 
-        # create two namespaces
-        _ = k8s_backend.create_namespace()
-        _ = k8s_backend.create_namespace()
+        # cleanup should delete two namespaces created with k8s backend
+        assert len(
+            [item for item in api.list_namespace().items
+             if item.status.phase != "Terminating"]) == number_of_namespaces
 
-    # cleanup should delete two namespaces created with k8s backend
-    assert len(
-        [item for item in api.list_namespace().items
-         if item.status.phase != "Terminating"]) == number_of_namespaces
+        with K8sBackend(api_key=api_key) as k8s_backend:
 
-    with K8sBackend(api_key=api_key) as k8s_backend:
+            # create two namespaces
+            k8s_backend.create_namespace()
+            k8s_backend.create_namespace()
 
-        # create two namespaces
-        _ = k8s_backend.create_namespace()
-        _ = k8s_backend.create_namespace()
-
-    # no cleanup - namespaces are not deleted after work with backend is finished
-    assert len(
-        [item for item in api.list_namespace().items
-         if item.status.phase != "Terminating"]) == number_of_namespaces + 2
+        # no cleanup - namespaces are not deleted after work with backend is finished
+        assert len(
+            [item for item in api.list_namespace().items
+             if item.status.phase != "Terminating"]) == number_of_namespaces + 2

--- a/tests/integration/test_openshift.py
+++ b/tests/integration/test_openshift.py
@@ -17,82 +17,89 @@
 """
 Tests for OpenShift backend
 """
+
 import logging
+import pytest
+
 from conu.backend.origin.backend import OpenshiftBackend
 from conu.backend.docker.backend import DockerBackend
-from conu.utils import get_oc_api_token
+from conu.utils import get_oc_api_token, oc_command_exists, is_oc_cluster_running
 
 
-def test_oc_s2i_remote():
-    api_key = get_oc_api_token()
-    with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
+@pytest.mark.skipif(not oc_command_exists(), reason="OpenShift is not installed!")
+@pytest.mark.skipif(not is_oc_cluster_running(), reason="OpenShift cluster is not running!")
+class TestOpenshift(object):
 
-        with DockerBackend(logging_level=logging.DEBUG) as backend:
-            python_image = backend.ImageClass("centos/python-36-centos7")
+    def test_oc_s2i_remote(self):
+        api_key = get_oc_api_token()
+        with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
 
-            OpenshiftBackend.login_to_registry('developer')
+            with DockerBackend(logging_level=logging.DEBUG) as backend:
+                python_image = backend.ImageClass("centos/python-36-centos7")
 
-            app_name = openshift_backend.new_app(
-                python_image,
-                source="https://github.com/openshift/django-ex.git",
-                project='myproject')
+                OpenshiftBackend.login_to_registry('developer')
 
-            try:
-                openshift_backend.wait_for_service(
-                    app_name=app_name,
-                    expected_output='Welcome to your Django application on OpenShift',
-                    timeout=300)
-            finally:
-                openshift_backend.clean_project(app_name)
+                app_name = openshift_backend.new_app(
+                    python_image,
+                    source="https://github.com/openshift/django-ex.git",
+                    project='myproject')
 
+                try:
+                    openshift_backend.wait_for_service(
+                        app_name=app_name,
+                        expected_output='Welcome to your Django application on OpenShift',
+                        timeout=300)
+                finally:
+                    openshift_backend.clean_project(app_name)
 
-def test_oc_s2i_local():
-    api_key = get_oc_api_token()
-    with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
+    def test_oc_s2i_local(self):
+        api_key = get_oc_api_token()
+        with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
 
-        with DockerBackend(logging_level=logging.DEBUG) as backend:
-            python_image = backend.ImageClass("centos/python-36-centos7")
+            with DockerBackend(logging_level=logging.DEBUG) as backend:
+                python_image = backend.ImageClass("centos/python-36-centos7")
 
-            OpenshiftBackend.login_to_registry('developer')
+                OpenshiftBackend.login_to_registry('developer')
 
-            app_name = openshift_backend.new_app(python_image,
-                                                 source="examples/openshift/standalone-test-app",
-                                                 project='myproject')
+                app_name = openshift_backend.new_app(
+                    python_image,
+                    source="examples/openshift/standalone-test-app",
+                    project='myproject')
 
-            try:
-                openshift_backend.wait_for_service(
-                    app_name=app_name,
-                    expected_output="Hello World from standalone WSGI application!",
-                    timeout=300)
-            finally:
-                openshift_backend.clean_project(app_name)
+                try:
+                    openshift_backend.wait_for_service(
+                        app_name=app_name,
+                        expected_output="Hello World from standalone WSGI application!",
+                        timeout=300)
+                finally:
+                    openshift_backend.clean_project(app_name)
 
+    def test_oc_s2i_template(self):
+        api_key = get_oc_api_token()
+        with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
 
-def test_oc_s2i_template():
-    api_key = get_oc_api_token()
-    with OpenshiftBackend(api_key=api_key, logging_level=logging.DEBUG) as openshift_backend:
+            with DockerBackend(logging_level=logging.DEBUG) as backend:
+                python_image = backend.ImageClass("centos/python-36-centos7", tag="latest")
+                psql_image = backend.ImageClass("centos/postgresql-96-centos7", tag="9.6")
 
-        with DockerBackend(logging_level=logging.DEBUG) as backend:
-            python_image = backend.ImageClass("centos/python-36-centos7", tag="latest")
-            psql_image = backend.ImageClass("centos/postgresql-96-centos7", tag="9.6")
+                OpenshiftBackend.login_to_registry('developer')
 
-            OpenshiftBackend.login_to_registry('developer')
+                app_name = openshift_backend.new_app(
+                    image=python_image,
+                    template="https://raw.githubusercontent.com/sclorg/django-ex"
+                             "/master/openshift/templates/django-postgresql.json",
+                    oc_new_app_args=["-p", "SOURCE_REPOSITORY_REF=master", "-p",
+                                     "PYTHON_VERSION=3.6",
+                                     "-p", "POSTGRESQL_VERSION=9.6"],
+                    name_in_template={"python": "3.6"},
+                    other_images=[{psql_image: "postgresql:9.6"}],
+                    project='myproject')
 
-            app_name = openshift_backend.new_app(
-                image=python_image,
-                template="https://raw.githubusercontent.com/sclorg/django-ex"
-                         "/master/openshift/templates/django-postgresql.json",
-                oc_new_app_args=["-p", "SOURCE_REPOSITORY_REF=master", "-p", "PYTHON_VERSION=3.6",
-                                 "-p", "POSTGRESQL_VERSION=9.6"],
-                name_in_template={"python": "3.6"},
-                other_images=[{psql_image: "postgresql:9.6"}],
-                project='myproject')
-
-            try:
-                openshift_backend.wait_for_service(
-                    app_name=app_name,
-                    expected_output='Welcome to your Django application on OpenShift',
-                    timeout=300)
-            finally:
-                # pass name from template as argument
-                openshift_backend.clean_project('django-psql-example')
+                try:
+                    openshift_backend.wait_for_service(
+                        app_name=app_name,
+                        expected_output='Welcome to your Django application on OpenShift',
+                        timeout=300)
+                finally:
+                    # pass name from template as argument
+                    openshift_backend.clean_project('django-psql-example')


### PR DESCRIPTION
This PR contains:

1.  move tests for k8s and origin backend to classes` TestK8s` and `TestOpenshift`.
2. skip k8s and origin tests if:
      -  oc command does not exist
      -  OpenShift cluster is not running
3. allow using `make test-in-container` even when ~/.kube directory doesn't exist on the host (k8s and OpenShift tests will be skipped)
