### PR TITLE
Enable copr builds for packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,15 @@
----
+dist_git_url: https://src.fedoraproject.org/rpms/conu.git
+downstream_package_name: conu
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-29-x86_64
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
 specfile_path: conu.spec
 synced_files:
-  - conu.spec
+- conu.spec
 upstream_project_name: conu
-downstream_package_name: conu
-dist_git_url: https://src.fedoraproject.org/rpms/conu.git


### PR DESCRIPTION
We enabled copr builds in the packit config for you.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact [@packit-service/the-packit-team](https://github.com/orgs/packit-service/teams/the-packit-team)
