### PR TITLE
Fix sphinx warnings

### DIFF
--- a/conu/apidefs/metadata.py
+++ b/conu/apidefs/metadata.py
@@ -49,9 +49,11 @@ class ContainerMetadata(Metadata):
         :param image: Image, reference to Image instance
         :param exposed_ports: list, list of exposed ports
         :param port_mappings: dict, dictionary of port mappings {"container_port": [host_port1]},
-               example:
-                    - {"1111/tcp":[1234, 4567]} bind host ports 1234 and 4567
-                     to a single container port 1111/tcp
+            
+            Example:
+
+            * {"1111/tcp":[1234, 4567]} bind host ports 1234 and 4567
+                to a single container port 1111/tcp
         :param hostname: str, hostname
         :param ipv4_addresses: dict, {address: port}
         :param ipv6_addresses: dict, {address: port}

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -231,8 +231,8 @@ class DockerImage(Image):
         """ change used transport
 
         :param transport: from where will be this image copied
-        :param path in filesystem
-        :param logs enable/disable
+        :param path: in filesystem
+        :param logs: enable/disable
         :return: self
         """
         if not transport:

--- a/conu/backend/k8s/pod.py
+++ b/conu/backend/k8s/pod.py
@@ -44,9 +44,11 @@ class Pod(object):
         :param namespace: str, namespace in which is pod created
         :param name: name of pod
         :param spec: pod spec
-        https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodSpec.md
+
+            * https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodSpec.md
         :param from_template: str, pod template, example:
-               - https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates
+        
+            * https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates
         """
         self.core_api = get_core_api()
         self.namespace = namespace

--- a/conu/backend/origin/backend.py
+++ b/conu/backend/origin/backend.py
@@ -158,8 +158,8 @@ class OpenshiftBackend(K8sBackend):
 
     def create_app_from_template(self, image_name, name, template, name_in_template,
                                  other_images=None, oc_new_app_args=None, project=None):
-        """
-        Helper function to create app from template
+        """Helper function to create app from template
+
         :param image_name: image to be used as builder image
         :param name: name of app from template
         :param template: str, url or local path to a template to use
@@ -222,8 +222,8 @@ class OpenshiftBackend(K8sBackend):
             raise ConuException("Cannot start build of application: %s" % e)
 
     def get_image_registry_url(self, image_name):
-        """
-        Helper function for obtain registry url of image from it's name
+        """Helper function for obtain registry url of image from it's name
+
         :param image_name: str, short name of an image, example:
             - conu:0.5.0
         :return: str, image registry url, example:
@@ -241,8 +241,8 @@ class OpenshiftBackend(K8sBackend):
         return internal_registry_name.replace("'", "").replace('"', '')
 
     def import_image(self, imported_image_name, image_name):
-        """
-        Import image using `oc import-image` command.
+        """Import image using `oc import-image` command.
+
         :param imported_image_name: str, short name of an image in internal registry, example:
             - hello-openshift:latest
         :param image_name: full repository name, example:
@@ -264,8 +264,8 @@ class OpenshiftBackend(K8sBackend):
         return imported_image_name
 
     def request_service(self, app_name, port, expected_output=None):
-        """
-        Make request on service of app. If there is connection error function return False.
+        """Make request on service of app. If there is connection error function return False.
+
         :param app_name: str, name of the app
         :param expected_output: str, If not None method will check output returned from request
                and try to find matching string.
@@ -296,9 +296,9 @@ class OpenshiftBackend(K8sBackend):
         return False
 
     def wait_for_service(self, app_name, port, expected_output=None, timeout=100):
-        """
-        Block until service is not ready to accept requests,
+        """Block until service is not ready to accept requests,
         raises an exc ProbeTimeout if timeout is reached
+
         :param app_name: str, name of the app
         :param port: str or int, port of the service
         :param expected_output: If not None method will check output returned from request

--- a/docs/source/new_releases.rst
+++ b/docs/source/new_releases.rst
@@ -3,6 +3,7 @@ How to release conu
 
 We are using awesome `release-bot <(https://github.com/user-cont/release-bot>`_ for new conu releases.
 If you want to make new release:
+
     - create new issue in Github upstream repository with title ``x.y.z release`` and wait for release bot to create new PR.
     - **polish CHANGELOG.md** and merge if tests are passing.
     - Sit down, relax and watch how release bot is doing the hard work.

--- a/docs/source/new_releases.rst
+++ b/docs/source/new_releases.rst
@@ -4,7 +4,7 @@ How to release conu
 We are using awesome `release-bot <(https://github.com/user-cont/release-bot>`_ for new conu releases.
 If you want to make new release:
 
-    - create new issue in Github upstream repository with title ``x.y.z release`` and wait for release bot to create new PR.
-    - **polish CHANGELOG.md** and merge if tests are passing.
-    - Sit down, relax and watch how release bot is doing the hard work.
+- create new issue in Github upstream repository with title ``x.y.z release`` and wait for release bot to create new PR.
+- **polish CHANGELOG.md** and merge if tests are passing.
+- Sit down, relax and watch how release bot is doing the hard work.
 


### PR DESCRIPTION
Hi,

This PR is a fix for #358 .

Sphinx output:

```
make -C docs/ html
make[1]: Entering directory '/tmp/conu-fork/docs'
Running Sphinx v2.2.0
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 25 source files that are out of date
updating environment: [new config] 25 added, 0 changed, 0 removed
reading sources... [  4%] asciinema
reading sources... [  8%] examples
reading sources... [ 12%] index
reading sources... [ 16%] installation
reading sources... [ 20%] new_releases
reading sources... [ 24%] reference/api_index
reading sources... [ 28%] reference/container
reading sources... [ 32%] reference/docker_container
reading sources... [ 36%] reference/docker_image
reading sources... [ 40%] reference/docker_index
reading sources... [ 44%] reference/filesystem_api
reading sources... [ 48%] reference/fixtures_index
reading sources... [ 52%] reference/helpers_index
reading sources... [ 56%] reference/image
reading sources... [ 60%] reference/index
reading sources... [ 64%] reference/k8s_deployment
reading sources... [ 68%] reference/k8s_index
reading sources... [ 72%] reference/k8s_pod
reading sources... [ 76%] reference/k8s_service
reading sources... [ 80%] reference/metadata
reading sources... [ 84%] reference/origin_index
reading sources... [ 88%] reference/other
reading sources... [ 92%] reference/probe
reading sources... [ 96%] reference/util_filesystem
reading sources... [100%] reference/util_index

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  4%] asciinema
writing output... [  8%] examples
writing output... [ 12%] index
writing output... [ 16%] installation
writing output... [ 20%] new_releases
writing output... [ 24%] reference/api_index
writing output... [ 28%] reference/container
writing output... [ 32%] reference/docker_container
writing output... [ 36%] reference/docker_image
writing output... [ 40%] reference/docker_index
writing output... [ 44%] reference/filesystem_api
writing output... [ 48%] reference/fixtures_index
writing output... [ 52%] reference/helpers_index
writing output... [ 56%] reference/image
writing output... [ 60%] reference/index
writing output... [ 64%] reference/k8s_deployment
writing output... [ 68%] reference/k8s_index
writing output... [ 72%] reference/k8s_pod
writing output... [ 76%] reference/k8s_service
writing output... [ 80%] reference/metadata
writing output... [ 84%] reference/origin_index
writing output... [ 88%] reference/other
writing output... [ 92%] reference/probe
writing output... [ 96%] reference/util_filesystem
writing output... [100%] reference/util_index

generating indices...  genindex py-modindexdone
writing additional pages...  searchdone
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.
make[1]: Leaving directory '/tmp/conu-fork/docs'

```