### PR TITLE
Few fixex fot execution tests in centos-ci

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -5,4 +5,6 @@ FROM docker.io/usercont/conu:dev
 RUN cp /usr/share/containers/libpod.conf /etc/containers/ \
     && sed -i '/cgroup_manager/ s/systemd/cgroupfs/' /etc/containers/libpod.conf \
     && sed -i '/^mountopt/ s/mountopt/# mountopt/' /etc/containers/storage.conf \
-    && sed -i 's/^# events_logger.\+$/events_logger = "none"/' /etc/containers/libpod.conf
+    && sed -i 's/^# events_logger.\+$/events_logger = "none"/' /etc/containers/libpod.conf \
+    && printf "unqualified-search-registries = ['registry.fedoraproject.org', 'registry.access.redhat.com', 'registry.centos.org', 'docker.io']\n" > /etc/containers/registries.conf \
+    && printf '[[registry]]\nprefix = "docker.io"\ninsecure = true\nlocation = "localhost:5000"\n' >> /etc/containers/registries.conf

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install-requirements:
 	ansible-playbook -vv -c local -i localhost, files/install-packages.yaml
 
 setup-oc-cluster-ci:
+	yum install -y epel-release && \
 	yum install -y ansible && \
 	ansible-playbook -vv -c local -i localhost, files/install-openshift.yaml
 

--- a/docs/source/examples/openshift/standalone-test-app/requirements.txt
+++ b/docs/source/examples/openshift/standalone-test-app/requirements.txt
@@ -1,1 +1,1 @@
-gunicorn
+gunicorn==19.10.0

--- a/files/install-openshift.yaml
+++ b/files/install-openshift.yaml
@@ -20,6 +20,25 @@
     systemd:
       name: docker
       state: started
+  - name: Create directory for registry configuration
+    file:
+      path: /etc/docker/registry/
+      state: directory
+  - name: Create configuration for registry proxy
+    copy:
+      src: registry_config.yml
+      dest: /etc/docker/registry/config.yml
+      mode: 0644
+  - name: Remove older container for registry mirror
+    command: docker rm -f registry
+    ignore_errors: yes
+  - name: Run registry proxy
+    command: >
+      docker run -d -p 5000:5000 --restart=always
+          --name registry
+          -v /etc/docker/registry/config.yml:/etc/docker/registry/config.yml
+          -v /var/lib/registry:/var/lib/registry:z
+          docker.io/registry:2
   - name: Create docker deamon config
     file:
       path: /etc/docker/daemon.json
@@ -27,7 +46,8 @@
   - name: Add OpenShift insecure registry into docker deamon config
     copy:
       content: |
-        {"insecure-registries" : [ "172.30.0.0/16" ]}
+        {"insecure-registries" : [ "172.30.0.0/16" ],
+         "registry-mirrors": ["http://localhost:5000"]}
       dest: /etc/docker/daemon.json
   - name: Restart docker because config has changed
     systemd:

--- a/files/install-openshift.yaml
+++ b/files/install-openshift.yaml
@@ -45,7 +45,7 @@
       - origin-clients
       state: present
   - name: Start Openshift cluster
-    command: oc cluster up --base-dir=/tmp
+    command: oc cluster up --base-dir=/var/tmp/openshift.local.clusterup --image='quay.io/openshift/origin-${component}:${version}'
     environment:
       PATH: "{{ ansible_env.PATH}}:/usr/local/bin"
       DOCKER_CONFIG: "/etc/docker/daemon.json"

--- a/files/install-openshift.yaml
+++ b/files/install-openshift.yaml
@@ -37,7 +37,7 @@
   - name: Install OpenShift server
     yum:
       name:
-      - centos-release-openshift-origin310
+      - centos-release-openshift-origin311
       state: present
   - name: Install OpenShift client
     yum:

--- a/files/registry_config.yml
+++ b/files/registry_config.yml
@@ -1,0 +1,25 @@
+# https://docs.docker.com/registry/recipes/mirror/
+# https://docs.docker.com/registry/configuration/
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+proxy:
+  remoteurl: https://registry-1.docker.io
+#  username: username
+#  password: xxxxxxxxx
+


### PR DESCRIPTION
* Enable epel for ansible
* Install the latest 3.x version of origin
* Use images from Quay for oc cluster up
* Pin dependencies for sample application
* Deploy and configure registry mirror to docker hup for docker daemon
* Use registry proxy also for podman 

The last two commits are tiny workaround for docker hub rate limit; but they are not sufficient
they just reduce impact a bit; necessary images for tests should be probably copied  to quay.io (conu namespace)